### PR TITLE
keep some string for truncated integer constants

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -2028,7 +2028,12 @@ let kintegerCilint (k: ikind) (i: cilint) : exp =
   if truncated = BitTruncation && !warnTruncate then 
     ignore (warnOpt "Truncating integer %s to %s" 
               (string_of_cilint i) (string_of_cilint i'));
-  Const (CInt64(int64_of_cilint i', k,  None))
+  let str =
+    if string_of_cilint i <> string_of_cilint i' then
+      Some (string_of_cilint i)
+    else None
+  in
+  Const (CInt64(int64_of_cilint i', k, str))
 
 (* Construct an integer constant with possible truncation *)
 let kinteger64 (k: ikind) (i: int64) : exp = 


### PR DESCRIPTION
See [CIL PR32](https://github.com/cil-project/cil/pull/32):

`CInt64` has a `string option` for the original representation, but it is always `None`.
Also, this should allow to check if it was truncated or not. See goblint/analyzer#59.