### PR TITLE
Add printer that prints CILs internal AST representation

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -3444,6 +3444,14 @@ class cilAstDumpClass : cilPrinter = object (self)
              Some s -> text "\"" ++ text s ++ text "\""
            | _ -> text "None")
        ++ text ")"
+    | CReal (f, fk, s) ->
+       text "CReal("
+       ++ real f ++ text ", "
+       ++ self#pFKind fk ++ text ", "
+       ++ (match s with
+             Some s -> text "\"" ++ text s ++ text "\""
+           | _ -> text "None")
+       ++ text ")"
     | _ -> failwith "Cannot print constant"
 
   method private pBinOp (bin: binop) : doc =

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -3456,6 +3456,7 @@ class cilAstDumpClass : cilPrinter = object (self)
 
   method private pBinOp (bin: binop) : doc =
     text (match bin with
+            PlusA -> "PlusA"
           | Mult -> "Mult"
           | _ -> failwith "Cannot print binop")
   

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -3491,8 +3491,8 @@ class cilAstDumpClass : cilPrinter = object (self)
     ++ text "vid: " ++ num v.vid ++ text ",\n"
     ++ text "vaddrof: " ++ text (string_of_bool v.vaddrof) ++ text ",\n"
     ++ text "vreferenced: " ++ text (string_of_bool v.vreferenced) ++ text ",\n"
-    ++ text "vdescr: " ++ v.vdescr ++ text ",\n"
-    ++ text "vdescrpure: " ++ text (string_of_bool v.vdescrpure) ++ text ",\n"
+    (* ++ text "vdescr: " ++ v.vdescr ++ text ",\n"
+     * ++ text "vdescrpure: " ++ text (string_of_bool v.vdescrpure) ++ text ",\n" *)
     ++ text "vhasdeclinstruction: " ++ text (string_of_bool v.vhasdeclinstruction) ++ text "\n"
     ++ text "}"
 

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -3565,7 +3565,7 @@ class cilAstDumpClass : cilPrinter = object (self)
   method pBlock () (b: block) : doc =
     text "block{"
     (* ++ text "battrs: " *)
-    ++ text ", bstmts: " ++ self#pList (self#pStmt ()) b.bstmts
+    ++ text "bstmts: " ++ self#pList (self#pStmt ()) b.bstmts
     ++ text "}"
 
   method pGlobal () (g: global) : doc =

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -3573,23 +3573,23 @@ class cilAstDumpClass : cilPrinter = object (self)
        text "GType("
        ++ self#pTypeInfo ti ++ text ", "
        ++ self#pLineDirective loc
-       ++ text ")"
+       ++ text ")\n"
     | GVarDecl (v, loc) ->
        text "GVarDecl("
        ++ self#pVDecl () v ++ text ", "
        ++ self#pLineDirective loc
-       ++ text ")"
+       ++ text ")\n"
     | GVar (v, ii, loc) ->
        text "GVar("
        ++ self#pVar v ++ text ", "
        ++ self#pInitInfo ii ++ text ", "
        ++ self#pLineDirective loc
-       ++ text ")"
+       ++ text ")\n"
     | GFun (fd, loc) ->
        text "GFun("
        ++ self#pFunDec fd ++ text ", "
        ++ self#pLineDirective loc
-       ++ text ")"
+       ++ text ")\n"
     | _ -> failwith "Cannot print global"
 
   method dGlobal (out: out_channel) (g: global) =

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -3704,6 +3704,10 @@ class cilAstDumpClass : cilPrinter = object (self)
        ++ self#pType None () t ++ text ", "
        ++ self#pExp () e
        ++ text ")"
+    | AddrOf lv ->
+       text "AddrOf("
+       ++ self#pLval () lv
+       ++ text ")"
     | _ -> failwith "Cannot print exp"
 
   method pInit () (i: init) : doc =

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -3406,9 +3406,9 @@ class cilAstDumpClass : cilPrinter = object (self)
     match l with
       [] -> text "[]"
     | h :: t -> let middle = List.fold_left
-                               (fun acc x -> acc ++ text "; " ++ x)
+                               (fun acc x -> acc ++ text ";\n" ++ x)
                                (f h) (List.map f t)
-                in text "[" ++ middle ++ text "]"
+                in text "[\n" ++ middle ++ text "\n]"
 
   method private pIKind (ik: ikind) : doc =
     text (match ik with
@@ -3454,10 +3454,11 @@ class cilAstDumpClass : cilPrinter = object (self)
   method private pFieldInfo (fi: fieldinfo) : doc = text "fieldinfo{}"
   
   method private pFunDec (fd: fundec) : doc =
-    text "fundec{svar: " ++ (self#pVar fd.svar)
-    ++ text ", sformals: " ++ self#pList self#pVar fd.sformals
-    ++ text ", slocals: " ++ self#pList self#pVar fd.slocals
-    ++ text ", sbody: " ++ (self#pBlock () fd.sbody)
+    text "fundec{\n"
+    ++ text "svar: " ++ self#pVar fd.svar ++ text ",\n"
+    ++ text "sformals: " ++ self#pList self#pVar fd.sformals ++ text ",\n"
+    ++ text "slocals: " ++ self#pList self#pVar fd.slocals ++ text ",\n"
+    ++ text "sbody: " ++ (self#pBlock () fd.sbody) ++ text "\n"
     ++ text "}"
 
   method private pInitInfo (ii: initinfo) : doc =
@@ -3471,27 +3472,29 @@ class cilAstDumpClass : cilPrinter = object (self)
     | Mem e -> text "Exp(" ++ self#pExp () e ++ text ")"
 
   method private pTypeInfo (ti: typeinfo) : doc =
-    (text "typeinfo{tname: ") ++ (text ti.tname)
-    ++ (text ", ttype: ") ++ (self#pType None () ti.ttype)
-    ++ (text ", treferenced: ") ++ (text (string_of_bool ti.treferenced))
-    ++ (text "}")
+    text "typeinfo{\n"
+    ++ text "tname: \"" ++ text ti.tname ++ text "\",\n"
+    ++ text "ttype: " ++ self#pType None () ti.ttype ++ text ",\n"
+    ++ text "treferenced: " ++ text (string_of_bool ti.treferenced) ++ text "\n"
+    ++ text "}"
 
   method pVDecl () (v: varinfo) : doc =
-    (text "varinfo{vname: ") ++ (text v.vname)
-    ++ (text ", vtype: ") ++ (self#pType None () v.vtype)
-    ++ (text ", vattr: ") ++ (self#pAttrs () v.vattr)
-    (* ++ (text ", vstorage: ") *)
-    ++ (text ", vglob: ") ++ (text (string_of_bool v.vglob))
-    ++ (text ", vinline: ") ++ (text (string_of_bool v.vinline))
-    ++ (text ", vdecl: ") ++ (self#pLineDirective v.vdecl)
-    ++ (text ", vinit: ") ++ (self#pInitInfo v.vinit)
-    ++ (text ", vid: ") ++ (num v.vid)
-    ++ (text ", vaddrof: ") ++ (text (string_of_bool v.vaddrof))
-    ++ (text ", vreferenced: ") ++ (text (string_of_bool v.vreferenced))
-    ++ (text ", vdescr: ") ++ v.vdescr
-    ++ (text ", vdescrpure: ") ++ (text (string_of_bool v.vdescrpure))
-    ++ (text ", vhasdeclinstruction: ") ++ (text (string_of_bool v.vhasdeclinstruction))
-    ++ (text "}")
+    text "varinfo{\n"
+    ++ text "vname: \"" ++ text v.vname ++ text "\",\n"
+    ++ text "vtype: " ++ self#pType None () v.vtype ++ text ",\n"
+    ++ text "vattr: " ++ self#pAttrs () v.vattr ++ text ",\n"
+    (* ++ (text "vstorage: ") *)
+    ++ text "vglob: " ++ text (string_of_bool v.vglob) ++ text ",\n"
+    ++ text "vinline: " ++ text (string_of_bool v.vinline) ++ text ",\n"
+    ++ text "vdecl: " ++ self#pLineDirective v.vdecl ++ text ",\n"
+    ++ text "vinit: " ++ self#pInitInfo v.vinit ++ text ",\n"
+    ++ text "vid: " ++ num v.vid ++ text ",\n"
+    ++ text "vaddrof: " ++ text (string_of_bool v.vaddrof) ++ text ",\n"
+    ++ text "vreferenced: " ++ text (string_of_bool v.vreferenced) ++ text ",\n"
+    ++ text "vdescr: " ++ v.vdescr ++ text ",\n"
+    ++ text "vdescrpure: " ++ text (string_of_bool v.vdescrpure) ++ text ",\n"
+    ++ text "vhasdeclinstruction: " ++ text (string_of_bool v.vhasdeclinstruction) ++ text "\n"
+    ++ text "}"
 
   method pVar (v: varinfo) : doc = self#pVDecl () v
 
@@ -3517,21 +3520,21 @@ class cilAstDumpClass : cilPrinter = object (self)
     match i with
       Set (lv, e, loc) ->
        text "Set("
-       ++ self#pLval () lv ++ text ", "
-       ++ self#pExp () e ++ text ", "
-       ++ self#pLineDirective loc
+       ++ self#pLval () lv ++ text ",\n"
+       ++ self#pExp () e ++ text ",\n"
+       ++ self#pLineDirective loc ++ text "\n"
        ++ text ")"
     | VarDecl (v, loc) ->
        text "VarDecl("
-       ++ self#pVDecl () v ++ text ", "
-       ++ self#pLineDirective loc
+       ++ self#pVDecl () v ++ text ",\n"
+       ++ self#pLineDirective loc ++ text "\n"
        ++ text ")"
     | Call (lv, e, args, loc) ->
        text "Call("
-       ++ (match lv with Some lv' -> self#pLval () lv' | _ -> text "None") ++ text ", "
-       ++ self#pExp () e ++ text ", "
-       ++ self#pList (self#pExp ()) args ++ text ", "
-       ++ self#pLineDirective loc
+       ++ (match lv with Some lv' -> self#pLval () lv' | _ -> text "None") ++ text ",\n"
+       ++ self#pExp () e ++ text ",\n"
+       ++ self#pList (self#pExp ()) args ++ text ",\n"
+       ++ self#pLineDirective loc ++ text "\n"
        ++ text ")"
     | Asm (_, _, _, _, _, _) -> failwith "Cannot print Asm"
 

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -3464,14 +3464,14 @@ class cilAstDumpClass : cilPrinter = object (self)
   
   method private pFunDec (fd: fundec) : doc =
     text "fundec{\n"
-    ++ text "svar: " ++ self#pVar fd.svar ++ text ",\n"
-    ++ text "sformals: " ++ self#pList self#pVar fd.sformals ++ text ",\n"
-    ++ text "slocals: " ++ self#pList self#pVar fd.slocals ++ text ",\n"
-    ++ text "sbody: " ++ (self#pBlock () fd.sbody) ++ text "\n"
+    ++ text "svar = " ++ self#pVar fd.svar ++ text ";\n"
+    ++ text "sformals = " ++ self#pList self#pVar fd.sformals ++ text ";\n"
+    ++ text "slocals = " ++ self#pList self#pVar fd.slocals ++ text ";\n"
+    ++ text "sbody = " ++ (self#pBlock () fd.sbody) ++ text "\n"
     ++ text "}"
 
   method private pInitInfo (ii: initinfo) : doc =
-    (text "initinfo{init: ")
+    (text "initinfo{init = ")
     ++ (match ii.init with Some i -> self#pInit () i | _ -> text "None")
     ++ (text "}")
 
@@ -3482,27 +3482,27 @@ class cilAstDumpClass : cilPrinter = object (self)
 
   method private pTypeInfo (ti: typeinfo) : doc =
     text "typeinfo{\n"
-    ++ text "tname: \"" ++ text ti.tname ++ text "\",\n"
-    ++ text "ttype: " ++ self#pType None () ti.ttype ++ text ",\n"
-    ++ text "treferenced: " ++ text (string_of_bool ti.treferenced) ++ text "\n"
+    ++ text "tname = \"" ++ text ti.tname ++ text "\";\n"
+    ++ text "ttype = " ++ self#pType None () ti.ttype ++ text ";\n"
+    ++ text "treferenced = " ++ text (string_of_bool ti.treferenced) ++ text "\n"
     ++ text "}"
 
   method pVDecl () (v: varinfo) : doc =
     text "varinfo{\n"
-    ++ text "vname: \"" ++ text v.vname ++ text "\",\n"
-    ++ text "vtype: " ++ self#pType None () v.vtype ++ text ",\n"
-    ++ text "vattr: " ++ self#pAttrs () v.vattr ++ text ",\n"
+    ++ text "vname = \"" ++ text v.vname ++ text "\";\n"
+    ++ text "vtype = " ++ self#pType None () v.vtype ++ text ";\n"
+    ++ text "vattr = " ++ self#pAttrs () v.vattr ++ text ";\n"
     (* ++ (text "vstorage: ") *)
-    ++ text "vglob: " ++ text (string_of_bool v.vglob) ++ text ",\n"
-    ++ text "vinline: " ++ text (string_of_bool v.vinline) ++ text ",\n"
-    ++ text "vdecl: " ++ self#pLineDirective v.vdecl ++ text ",\n"
-    ++ text "vinit: " ++ self#pInitInfo v.vinit ++ text ",\n"
-    ++ text "vid: " ++ num v.vid ++ text ",\n"
-    ++ text "vaddrof: " ++ text (string_of_bool v.vaddrof) ++ text ",\n"
-    ++ text "vreferenced: " ++ text (string_of_bool v.vreferenced) ++ text ",\n"
+    ++ text "vglob = " ++ text (string_of_bool v.vglob) ++ text ";\n"
+    ++ text "vinline = " ++ text (string_of_bool v.vinline) ++ text ";\n"
+    ++ text "vdecl = " ++ self#pLineDirective v.vdecl ++ text ";\n"
+    ++ text "vinit = " ++ self#pInitInfo v.vinit ++ text ";\n"
+    ++ text "vid = " ++ num v.vid ++ text ";\n"
+    ++ text "vaddrof = " ++ text (string_of_bool v.vaddrof) ++ text ";\n"
+    ++ text "vreferenced = " ++ text (string_of_bool v.vreferenced) ++ text ";\n"
     (* ++ text "vdescr: " ++ v.vdescr ++ text ",\n"
      * ++ text "vdescrpure: " ++ text (string_of_bool v.vdescrpure) ++ text ",\n" *)
-    ++ text "vhasdeclinstruction: " ++ text (string_of_bool v.vhasdeclinstruction) ++ text "\n"
+    ++ text "vhasdeclinstruction = " ++ text (string_of_bool v.vhasdeclinstruction) ++ text "\n"
     ++ text "}"
 
   method pVar (v: varinfo) : doc = self#pVDecl () v
@@ -3548,10 +3548,10 @@ class cilAstDumpClass : cilPrinter = object (self)
     | Asm (_, _, _, _, _, _) -> failwith "Cannot print Asm"
 
   method pStmt () (s: stmt) : doc =
-    text "stmt{"
+    text "stmt{\n"
     (* ++ text "labels: " *)
-    ++ text "skind: " ++ self#pStmtKind s () s.skind
-    ++ text ", sid: " ++ num s.sid
+    ++ text "skind = " ++ self#pStmtKind s () s.skind ++ text ";\n"
+    ++ text "sid = " ++ num s.sid ++ text "\n"
     (* ++ text ", succs: "
      * ++ text ", preds: " *)
     ++ text "}"
@@ -3565,7 +3565,7 @@ class cilAstDumpClass : cilPrinter = object (self)
   method pBlock () (b: block) : doc =
     text "block{"
     (* ++ text "battrs: " *)
-    ++ text "bstmts: " ++ self#pList (self#pStmt ()) b.bstmts
+    ++ text "bstmts = " ++ self#pList (self#pStmt ()) b.bstmts
     ++ text "}"
 
   method pGlobal () (g: global) : doc =
@@ -3574,23 +3574,23 @@ class cilAstDumpClass : cilPrinter = object (self)
        text "GType("
        ++ self#pTypeInfo ti ++ text ", "
        ++ self#pLineDirective loc
-       ++ text ")\n"
+       ++ text ");;\n"
     | GVarDecl (v, loc) ->
        text "GVarDecl("
        ++ self#pVDecl () v ++ text ", "
        ++ self#pLineDirective loc
-       ++ text ")\n"
+       ++ text ");;\n"
     | GVar (v, ii, loc) ->
        text "GVar("
        ++ self#pVar v ++ text ", "
        ++ self#pInitInfo ii ++ text ", "
        ++ self#pLineDirective loc
-       ++ text ")\n"
+       ++ text ");;\n"
     | GFun (fd, loc) ->
        text "GFun("
        ++ self#pFunDec fd ++ text ", "
        ++ self#pLineDirective loc
-       ++ text ")\n"
+       ++ text ");;\n"
     | _ -> failwith "Cannot print global"
 
   method dGlobal (out: out_channel) (g: global) =
@@ -3668,9 +3668,9 @@ class cilAstDumpClass : cilPrinter = object (self)
 
   method pLineDirective ?forcefile:bool (loc: location) : doc =
     text "location{"
-    ++ text "line: " ++ num loc.line
-    ++ text ", file: \"" ++ text loc.file ++ text "\""
-    ++ text ", byte: " ++ num loc.byte
+    ++ text "line = " ++ num loc.line
+    ++ text "; file = \"" ++ text loc.file ++ text "\""
+    ++ text "; byte = " ++ num loc.byte
     ++ text "}"
 
   method pStmtKind (_: stmt) () (sk: stmtkind) : doc =


### PR DESCRIPTION
This can be helpful for understanding how `C` code is represented by `Cil`.