### PR TITLE
Pointer analysis fixes

### DIFF
--- a/src/ext/pta/ptranal.ml
+++ b/src/ext/pta/ptranal.ml
@@ -288,17 +288,16 @@ let analyze_instr (i : instr ) : unit =
         else (* todo : check to see if the thing is an undefined function *)
           let fnres, site =
             if is_undefined_fun fexpr && !conservative_undefineds then
-              A.apply_undefined (Util.list_map analyze_expr actuals)
+              begin
+                found_undefined := true;
+                A.apply_undefined (Util.list_map analyze_expr actuals)
+              end
             else
               A.apply (analyze_expr fexpr) (Util.list_map analyze_expr actuals)
           in
             begin
               match res with
-                  Some r ->
-                    begin
-                      A.assign_ret site (analyze_lval r) fnres;
-                      found_undefined := true;
-                    end
+                  Some r -> A.assign_ret site (analyze_lval r) fnres
                 | None -> ()
             end
     | Asm _ -> ()

--- a/src/ext/pta/ptranal.ml
+++ b/src/ext/pta/ptranal.ml
@@ -255,8 +255,8 @@ and analyze_expr (e : exp ) : A.tau =
       | StartOf l -> A.address (analyze_lval l)
       | AlignOfE _ -> A.bottom ()
       | SizeOfE _ -> A.bottom ()
-      | Imag __ -> failwith "not implemented yet"
-      | Real __ -> failwith "not implemented yet"
+      | Imag __ -> A.bottom ()
+      | Real __ -> A.bottom ()
  in
   H.add expressions e result;
   result


### PR DESCRIPTION
This PR fixes two problems in the pointer analysis extension of CIL.

The first commit doesn't need much explanation. ``analyze_expr`` returns ``A.bottom ()`` for numeric expressions like ``Const`` & ``SizeOf``, so it should work for ``Real`` & ``Imag`` as well.

The second commit is slightly more complicated: pta has a conservative analysis mode. When it's enabled, pta makes the most pessimistic assumptions about undefined functions and hoses all the global pointers. Normally, ``analyze_file`` is supposed to set ``found_undefined`` to true when it encounters a call to an ``extern`` function so that ``compute_results`` can decide whether it should hose or not. However, what actually happens is that ``analyze_instr`` toggles ``found_undefined`` as soon as it encounters a call to a function (undefined or not) where the caller doesn't discard the return value. Here is an example:

```c
int i;
int *p = &i;

int f(void) { return 0; }

int main(void) {
  i = f(); // `p` is hosed even though `f` is defined
}
```

and the output of pta:

```
$ main --doptranal --ptr_results --ptr_conservative example.c
Computing points-to sets...
Total number of things pointed to: 0
```

Output after the fix is applied:
```
Computing points-to sets...
p(1) -> i
Total number of things pointed to: 1
```