### PR TITLE
Equip CIL with a mapping maintaining variable names before/after alpha conversion.

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -339,7 +339,9 @@ type envdata =
 
 let env : (string, envdata * location) H.t = H.create 307
 
-let myEnv : (string, envdata * location) H.t = H.create 307
+(* Just like env, except that it simply collects all the information (i.e. entries
+ * are never removed and it is also not emptied after every file). *)
+let environment : (string, envdata * location) H.t = H.create 307
 
 (* We also keep a global environment. This is always a subset of the env *)
 let genv : (string, envdata * location) H.t = H.create 307
@@ -364,7 +366,7 @@ let isAtTopLevel () =
 let addLocalToEnv (n: string) (d: envdata) =
 (*  ignore (E.log "%a: adding local %s to env\n" d_loc !currentLoc n); *)
   H.add env n (d, !currentLoc);
-  H.add myEnv n (d, !currentLoc);
+  H.add environment n (d, !currentLoc);
     (* If we are in a scope, then it means we are not at top level. Add the
      * name to the scope *)
   (match !scopes with
@@ -381,7 +383,7 @@ let addLocalToEnv (n: string) (d: envdata) =
 let addGlobalToEnv (k: string) (d: envdata) : unit =
 (*  ignore (E.log "%a: adding global %s to env\n" d_loc !currentLoc k); *)
   H.add env k (d, !currentLoc);
-  H.add myEnv k (d, !currentLoc);
+  H.add environment k (d, !currentLoc);
   (* Also add it to the global environment *)
   H.add genv k (d, !currentLoc)
 
@@ -437,7 +439,7 @@ let newAlphaName (globalscope: bool) (* The name should have global scope *)
     findEnclosingFun !scopes;
   let newname, oldloc =
            AL.newAlphaName ~alphaTable:alphaTable ~undolist:None ~lookupname:lookupname ~data:!currentLoc in
-  H.add varnameMapping origname newname; 
+  H.add varnameMapping origname newname;
   stripKind kind newname, oldloc
 
 

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -339,7 +339,7 @@ let env : (string, envdata * location) H.t = H.create 307
 (* We also keep a global environment. This is always a subset of the env *)
 let genv : (string, envdata * location) H.t = H.create 307
 
-let absolutenv : (string, envdata * location) H.t = H.create 307
+let varnameMapping : (string, string) H.t = H.create 307
 
  (* In the scope we keep the original name, so we can remove them from the
   * hash table easily *)
@@ -430,6 +430,7 @@ let newAlphaName (globalscope: bool) (* The name should have global scope *)
     findEnclosingFun !scopes;
   let newname, oldloc =
            AL.newAlphaName ~alphaTable:alphaTable ~undolist:None ~lookupname:lookupname ~data:!currentLoc in
+  H.add varnameMapping origname newname; 
   stripKind kind newname, oldloc
 
 

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -338,6 +338,9 @@ type envdata =
                                          * for this category is "label foo" *)
 
 let env : (string, envdata * location) H.t = H.create 307
+
+let myEnv : (string, envdata * location) H.t = H.create 307
+
 (* We also keep a global environment. This is always a subset of the env *)
 let genv : (string, envdata * location) H.t = H.create 307
 
@@ -361,6 +364,7 @@ let isAtTopLevel () =
 let addLocalToEnv (n: string) (d: envdata) =
 (*  ignore (E.log "%a: adding local %s to env\n" d_loc !currentLoc n); *)
   H.add env n (d, !currentLoc);
+  H.add myEnv n (d, !currentLoc);
     (* If we are in a scope, then it means we are not at top level. Add the
      * name to the scope *)
   (match !scopes with
@@ -377,6 +381,7 @@ let addLocalToEnv (n: string) (d: envdata) =
 let addGlobalToEnv (k: string) (d: envdata) : unit =
 (*  ignore (E.log "%a: adding global %s to env\n" d_loc !currentLoc k); *)
   H.add env k (d, !currentLoc);
+  H.add myEnv k (d, !currentLoc);
   (* Also add it to the global environment *)
   H.add genv k (d, !currentLoc)
 

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -143,6 +143,8 @@ let withCprint (f: 'a -> unit) (x: 'a) : unit =
  * hold the result of function calls *)
 let callTempVars: unit IH.t = IH.create 13
 
+let allTempVars: unit IH.t = IH.create 13
+
 (* Keep a list of functions that were called without a prototype. *)
 let noProtoFunctions : bool IH.t = IH.create 13
 
@@ -4609,6 +4611,7 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
               (* Remember that this variable has been created for this
                * specific call. We will use this in collapseCallCast. *)
               IH.add callTempVars tmp.vid ();
+              IH.add allTempVars tmp.vid ();
               addCall (Some (var tmp)) (Lval(var tmp)) restype''
           end
         end;

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -339,6 +339,8 @@ let env : (string, envdata * location) H.t = H.create 307
 (* We also keep a global environment. This is always a subset of the env *)
 let genv : (string, envdata * location) H.t = H.create 307
 
+let absolutenv : (string, envdata * location) H.t = H.create 307
+
  (* In the scope we keep the original name, so we can remove them from the
   * hash table easily *)
 type undoScope =

--- a/src/frontc/cabs2cil.mli
+++ b/src/frontc/cabs2cil.mli
@@ -35,8 +35,6 @@
  *
  *)
 
- open Cil
-
 (** The main entry point *)
 val convFile: Cabs.file -> Cil.file
 
@@ -92,12 +90,12 @@ val varnameMapping : (string, string) Hashtbl.t
 val allTempVars: unit Inthash.t
 
 type envdata =
-    EnvVar of varinfo                   (* The name refers to a variable
+    EnvVar of Cil.varinfo                   (* The name refers to a variable
                                          * (which could also be a function) *)
-  | EnvEnum of exp * typ                (* The name refers to an enumeration
+  | EnvEnum of Cil.exp * Cil.typ                (* The name refers to an enumeration
                                          * tag for which we know the value
                                          * and the host type *)
-  | EnvTyp of typ                       (* The name is of the form  "struct
+  | EnvTyp of Cil.typ                       (* The name is of the form  "struct
                                          * foo", or "union foo" or "enum foo"
                                          * and refers to a type. Note that
                                          * the name of the actual type might
@@ -107,5 +105,5 @@ type envdata =
                                          * is useful for GCC's locally
                                          * declared labels. The lookup name
                                          * for this category is "label foo" *)
-
-val myEnv : (string, envdata * location) Hashtbl.t 
+(** A hashtable containing a mapping of variables, enums, types and labels to varinfo, typ, etc. *)
+val myEnv : (string, envdata * Cil.location) Hashtbl.t 

--- a/src/frontc/cabs2cil.mli
+++ b/src/frontc/cabs2cil.mli
@@ -1,11 +1,11 @@
 (*
  *
- * Copyright (c) 2001-2002, 
+ * Copyright (c) 2001-2002,
  *  George C. Necula    <necula@cs.berkeley.edu>
  *  Scott McPeak        <smcpeak@cs.berkeley.edu>
  *  Wes Weimer          <weimer@cs.berkeley.edu>
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
@@ -41,7 +41,7 @@ val convFile: Cabs.file -> Cil.file
 (** Turn on tranformation that forces correct parameter evaluation order *)
 val forceRLArgEval: bool ref
 
-(** Set this integer to the index of the global to be left in CABS form. Use 
+(** Set this integer to the index of the global to be left in CABS form. Use
  * -1 to disable *)
 val nocil: int ref
 
@@ -74,7 +74,7 @@ val typeForTypeof: (Cil.typ -> Cil.typ) ref
   types of cabs2cil-introduced temp variables. *)
 val typeForInsertedVar: (Cil.typ -> Cil.typ) ref
 
-(** Like [typeForInsertedVar], but for casts.  
+(** Like [typeForInsertedVar], but for casts.
   * Casts in the source code are exempt from this hook. *)
 val typeForInsertedCast: (Cil.typ -> Cil.typ) ref
 
@@ -106,4 +106,4 @@ type envdata =
                                          * declared labels. The lookup name
                                          * for this category is "label foo" *)
 (** A hashtable containing a mapping of variables, enums, types and labels to varinfo, typ, etc. *)
-val myEnv : (string, envdata * Cil.location) Hashtbl.t 
+val environment : (string, envdata * Cil.location) Hashtbl.t

--- a/src/frontc/cabs2cil.mli
+++ b/src/frontc/cabs2cil.mli
@@ -35,6 +35,8 @@
  *
  *)
 
+ open Cil
+
 (** The main entry point *)
 val convFile: Cabs.file -> Cil.file
 
@@ -88,3 +90,22 @@ val attrsForCombinedArg: ((string, string) Hashtbl.t ->
 val varnameMapping : (string, string) Hashtbl.t
 
 val allTempVars: unit Inthash.t
+
+type envdata =
+    EnvVar of varinfo                   (* The name refers to a variable
+                                         * (which could also be a function) *)
+  | EnvEnum of exp * typ                (* The name refers to an enumeration
+                                         * tag for which we know the value
+                                         * and the host type *)
+  | EnvTyp of typ                       (* The name is of the form  "struct
+                                         * foo", or "union foo" or "enum foo"
+                                         * and refers to a type. Note that
+                                         * the name of the actual type might
+                                         * be different from foo due to alpha
+                                         * conversion *)
+  | EnvLabel of string                  (* The name refers to a label. This
+                                         * is useful for GCC's locally
+                                         * declared labels. The lookup name
+                                         * for this category is "label foo" *)
+
+val myEnv : (string, envdata * location) Hashtbl.t 

--- a/src/frontc/cabs2cil.mli
+++ b/src/frontc/cabs2cil.mli
@@ -85,21 +85,4 @@ val typeForCombinedArg: ((string, string) Hashtbl.t -> Cil.typ -> Cil.typ) ref
 val attrsForCombinedArg: ((string, string) Hashtbl.t ->
                           Cil.attributes -> Cil.attributes) ref
 
-type envdata =
-    EnvVar of Cil.varinfo                   (* The name refers to a variable
-                                         * (which could also be a function) *)
-  | EnvEnum of Cil.exp * Cil.typ                (* The name refers to an enumeration
-                                         * tag for which we know the value
-                                         * and the host type *)
-  | EnvTyp of Cil.typ                       (* The name is of the form  "struct
-                                         * foo", or "union foo" or "enum foo"
-                                         * and refers to a type. Note that
-                                         * the name of the actual type might
-                                         * be different from foo due to alpha
-                                         * conversion *)
-  | EnvLabel of string                  (* The name refers to a label. This
-                                         * is useful for GCC's locally
-                                         * declared labels. The lookup name
-                                         * for this category is "label foo" *)
-
-val absolutenv : (string, envdata * Cil.location) Hashtbl.t 
+val varnameMapping : (string, string) Hashtbl.t

--- a/src/frontc/cabs2cil.mli
+++ b/src/frontc/cabs2cil.mli
@@ -86,3 +86,5 @@ val attrsForCombinedArg: ((string, string) Hashtbl.t ->
                           Cil.attributes -> Cil.attributes) ref
 
 val varnameMapping : (string, string) Hashtbl.t
+
+val allTempVars: unit Inthash.t

--- a/src/frontc/cabs2cil.mli
+++ b/src/frontc/cabs2cil.mli
@@ -84,3 +84,22 @@ val typeForCombinedArg: ((string, string) Hashtbl.t -> Cil.typ -> Cil.typ) ref
 (** A hook into the code that merges arguments in function attributes. *)
 val attrsForCombinedArg: ((string, string) Hashtbl.t ->
                           Cil.attributes -> Cil.attributes) ref
+
+type envdata =
+    EnvVar of Cil.varinfo                   (* The name refers to a variable
+                                         * (which could also be a function) *)
+  | EnvEnum of Cil.exp * Cil.typ                (* The name refers to an enumeration
+                                         * tag for which we know the value
+                                         * and the host type *)
+  | EnvTyp of Cil.typ                       (* The name is of the form  "struct
+                                         * foo", or "union foo" or "enum foo"
+                                         * and refers to a type. Note that
+                                         * the name of the actual type might
+                                         * be different from foo due to alpha
+                                         * conversion *)
+  | EnvLabel of string                  (* The name refers to a label. This
+                                         * is useful for GCC's locally
+                                         * declared labels. The lookup name
+                                         * for this category is "label foo" *)
+
+val absolutenv : (string, envdata * Cil.location) Hashtbl.t 


### PR DESCRIPTION
**This is work by our student @faddeenkov which she undertook as part of her BA thesis.**

The idea is to maintain a mapping between the original name a variable had in the C program and the name it has after the alpha-conversion performed by CIL.
This also adds a list of all CIL variables that are temporary variables created by CIL. Until now, there was no reliable way to see if a variable is a temporary CIL variable or not (at least as far as I am aware).

This seems relevant in quite a number of places:
- It is one of the prerequisites for merging the rest of the work for that thesis and https://github.com/goblint/analyzer/pull/112 into Goblint (semantic search)
- It might be interesting to have this available for the HTML output
- This information might be helpful for generating witnesses (CC: @sim642)