### PR TITLE
Use unthreaded Batteries

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,7 @@ Changes:
     stdlib-shims
     ppx_deriving_yojson
     yojson
-    batteries
+    (batteries (>= 3.2.0))
   )
   (conflicts cil)
 )

--- a/goblint-cil.opam
+++ b/goblint-cil.opam
@@ -27,7 +27,7 @@ depends: [
   "stdlib-shims"
   "ppx_deriving_yojson"
   "yojson"
-  "batteries"
+  "batteries" {>= "3.2.0"}
 ]
 conflicts: ["cil"]
 build: [

--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,7 @@
   (public_name goblint-cil)
   (name cil)
   (wrapped false) ; this should be changed, but then module paths in goblint need to be prefixed
-  (libraries zarith findlib dynlink unix str stdlib-shims batteries)
+  (libraries zarith findlib dynlink unix str stdlib-shims batteries.unthreaded)
   (modules (:standard \ main))
 )
 

--- a/src/ext/syntacticsearch/dune
+++ b/src/ext/syntacticsearch/dune
@@ -2,6 +2,6 @@
   (public_name goblint-cil.syntacticsearch)
   (name syntacticsearch)
   (wrapped false) ; this should be changed, but then module paths in goblint need to be prefixed
-  (libraries goblint-cil yojson ppx_deriving_yojson.runtime batteries)
+  (libraries goblint-cil yojson ppx_deriving_yojson.runtime batteries.unthreaded)
   (preprocess (pps ppx_deriving_yojson))
 )


### PR DESCRIPTION
Since JavaScript is single-threaded, [Gobview](https://github.com/goblint/gobview) needs this to function correctly. When the default `batteries` package is used, CIL still compiles, but the JS bundle fails at runtime because it tries to call `caml_thread_initialize`, which isn't defined in the browser.