### PR TITLE
Fix infinite recursion in syntactic search

### DIFF
--- a/src/ext/syntacticsearch/funcVar.ml
+++ b/src/ext/syntacticsearch/funcVar.ml
@@ -181,8 +181,6 @@ let rec search_stmt_list_for_var list name varid includeCallTmp =
           search_instr_list_for_var ins_list name varid includeCallTmp
       | Return (Some exp, loc) ->
           search_expression exp name loc varid includeCallTmp
-      | Goto (s_ref, _) ->
-          search_stmt_list_for_var [ !s_ref ] name varid includeCallTmp
       | ComputedGoto (exp, loc) ->
           search_expression exp name loc varid includeCallTmp
       | If (exp, b1, b2, loc) ->

--- a/src/ext/syntacticsearch/resultPrinter.ml
+++ b/src/ext/syntacticsearch/resultPrinter.ml
@@ -1,5 +1,6 @@
 open CodeQuery
 open Cil
+open Feature
 
 let rec contains list elem =
   match list with
@@ -71,3 +72,24 @@ let print_result result query =
   if print_name || print_loc || print_typ || print_id then
     create_printout result
   else ""
+
+let query_file_name = ref ""
+
+let feature = {
+  fd_name = "syntacticsearch";
+  fd_enabled = false;
+  fd_description = "Syntactic Search in CIL programs";
+  fd_extraopt = [
+    ("--syntacticsearch_query_file",
+     Arg.Set_string query_file_name,
+     "<fname> Name of the file containing the syntactic search query")
+  ];
+  fd_doit = (fun f ->
+    Printexc.record_backtrace true;
+    let q = CodeQuery.parse_json_file !query_file_name in
+    let results = QueryMapping.map_query q f in
+    print_endline (print_result results q));
+  fd_post_check = false
+}
+
+let () = Feature.register feature


### PR DESCRIPTION
When the function `search_stmt_list_for_var` comes across a `Goto`, it extracts the `stmt` reference inside the `Goto` and recursively calls itself on the `stmt`. This is usually fine, but in the case of a backward jump, this `stmt` might contain a reference to the same `Goto`, which causes `search_stmt_list_for_var` to call itself in a loop until CIL crashes. This is fixed by not matching `Goto` in `search_stmt_list_for_var`. Since any statement that is referenced by a `Goto` will also appear in `sbody` of the function definition, this shouldn't cause any issues.

Example C file:
```c
#include <stdio.h>
#include <stdlib.h>

int f(int x) {
  int a = 1;
loop:
  // If you uncomment the following line, CIL no longer crashes because Goto
  // only references this assignment and no infinite recursion occurs.
  // x = x;
  if (x <= 0) {
    return a;
  } else {
    a *= x;
    --x;
    goto loop; // Backward jump. Goto references the if-else block, which
               // contains this Goto. Causes infinite recursion.
  }
}

int g() {
  int *p = malloc(sizeof(*p));
  if (!p) {
    goto cleanup; // Forward jump, doesn't cause any issues
  }
  *p = 42;
cleanup:
  free(p);
  return 0;
}

int main(void) { printf("fac(5) = %d\n", f(5)); }
```

Example query:
```json
{
    "select": [["name"], ["location"], ["type"], ["id"]],
    "type": ["var"],
    "target": ["or", ["p", "x"]],
    "find": ["uses"]
}
```

Program invocation:
```
dune exec -- ./src/main.bc --dosyntacticsearch --syntacticsearch_query_file query.json main.c
```

Output:
```
Fatal error: exception Stack overflow
Raised by primitive operation at file "src/ext/syntacticsearch/funcVar.ml", line 218, characters 8-61
Called from file "src/ext/syntacticsearch/funcVar.ml", line 191, characters 12-72
Called from file "src/ext/syntacticsearch/funcVar.ml", line 185, characters 10-71
Called from file "src/ext/syntacticsearch/funcVar.ml", line 218, characters 8-61
Called from file "src/ext/syntacticsearch/funcVar.ml", line 191, characters 12-72
Called from file "src/ext/syntacticsearch/funcVar.ml", line 185, characters 10-71
Called from file "src/ext/syntacticsearch/funcVar.ml", line 218, characters 8-61
Called from file "src/ext/syntacticsearch/funcVar.ml", line 191, characters 12-72
Called from file "src/ext/syntacticsearch/funcVar.ml", line 185, characters 10-71
Called from file "src/ext/syntacticsearch/funcVar.ml", line 218, characters 8-61
Called from file "src/ext/syntacticsearch/funcVar.ml", line 191, characters 12-72
Called from file "src/ext/syntacticsearch/funcVar.ml", line 185, characters 10-71
Called from file "src/ext/syntacticsearch/funcVar.ml", line 218, characters 8-61
Called from file "src/ext/syntacticsearch/funcVar.ml", line 191, characters 12-72
Called from file "src/ext/syntacticsearch/funcVar.ml", line 185, characters 10-71
Called from file "src/ext/syntacticsearch/funcVar.ml", line 218, characters 8-61
Called from file "src/ext/syntacticsearch/funcVar.ml", line 191, characters 12-72
Called from file "src/ext/syntacticsearch/funcVar.ml", line 185, characters 10-71
Called from file "src/ext/syntacticsearch/funcVar.ml", line 218, characters 8-61
[...]
```