### PR TITLE
Remove varnameMapping from `cabs2cil`

### DIFF
--- a/src/ext/syntacticsearch/funcFunction.ml
+++ b/src/ext/syntacticsearch/funcFunction.ml
@@ -18,7 +18,7 @@ let rec delete_duplicates list acc =
 
 let map_gfun f = function GFun (dec, loc) -> f dec loc | _ -> None
 
-let find_all_orignames n =
+let find_all_with_origname n =
   let ns = Hashtbl.find_all environment n in
   BatList.filter_map (function | (EnvVar v,_) -> Some v.vname | _ -> None) ns
 
@@ -259,7 +259,7 @@ let find_usesvar_in_fun funname funid funstrucname varname file =
   | Some fundec ->
       let result = ref [] in
       let dedup =
-        delete_duplicates (find_all_orignames varname) []
+        delete_duplicates (find_all_with_origname varname) []
       in
       List.iter
         (fun x ->
@@ -373,7 +373,7 @@ class find_calls_usesvar_with_tmp result funname funid varname : nopCilVisitor =
                     (List.map
                        (fun x ->
                          FuncVar.search_expression_list arg_list x loc (-1) true)
-                       (find_all_orignames varname)))
+                       (find_all_with_origname varname)))
                > 0
           then
             match lval_opt with

--- a/src/ext/syntacticsearch/funcFunction.ml
+++ b/src/ext/syntacticsearch/funcFunction.ml
@@ -18,6 +18,10 @@ let rec delete_duplicates list acc =
 
 let map_gfun f = function GFun (dec, loc) -> f dec loc | _ -> None
 
+let find_all_orignames n =
+  let ns = Hashtbl.find_all environment n in
+  BatList.filter_map (function | (EnvVar v,_) -> Some v.vname | _ -> None) ns
+
 class fun_find_returns funname funid result : nopCilVisitor =
   object
     inherit nopCilVisitor
@@ -255,7 +259,7 @@ let find_usesvar_in_fun funname funid funstrucname varname file =
   | Some fundec ->
       let result = ref [] in
       let dedup =
-        delete_duplicates (Hashtbl.find_all varnameMapping varname) []
+        delete_duplicates (find_all_orignames varname) []
       in
       List.iter
         (fun x ->
@@ -369,7 +373,7 @@ class find_calls_usesvar_with_tmp result funname funid varname : nopCilVisitor =
                     (List.map
                        (fun x ->
                          FuncVar.search_expression_list arg_list x loc (-1) true)
-                       (Hashtbl.find_all varnameMapping varname)))
+                       (find_all_orignames varname)))
                > 0
           then
             match lval_opt with

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -346,8 +346,6 @@ let environment : (string, envdata * location) H.t = H.create 307
 (* We also keep a global environment. This is always a subset of the env *)
 let genv : (string, envdata * location) H.t = H.create 307
 
-let varnameMapping : (string, string) H.t = H.create 307
-
  (* In the scope we keep the original name, so we can remove them from the
   * hash table easily *)
 type undoScope =
@@ -439,7 +437,6 @@ let newAlphaName (globalscope: bool) (* The name should have global scope *)
     findEnclosingFun !scopes;
   let newname, oldloc =
            AL.newAlphaName ~alphaTable:alphaTable ~undolist:None ~lookupname:lookupname ~data:!currentLoc in
-  H.add varnameMapping origname newname;
   stripKind kind newname, oldloc
 
 

--- a/src/frontc/cabs2cil.mli
+++ b/src/frontc/cabs2cil.mli
@@ -85,8 +85,6 @@ val typeForCombinedArg: ((string, string) Hashtbl.t -> Cil.typ -> Cil.typ) ref
 val attrsForCombinedArg: ((string, string) Hashtbl.t ->
                           Cil.attributes -> Cil.attributes) ref
 
-val varnameMapping : (string, string) Hashtbl.t
-
 val allTempVars: unit Inthash.t
 
 type envdata =
@@ -106,4 +104,5 @@ type envdata =
                                          * declared labels. The lookup name
                                          * for this category is "label foo" *)
 (** A hashtable containing a mapping of variables, enums, types and labels to varinfo, typ, etc. *)
+(*  It enables a lookup of the original variable names before the alpha conversion by cabs2cil *)
 val environment : (string, envdata * Cil.location) Hashtbl.t


### PR DESCRIPTION
We discovered in #31 that it is superfluous.