### PR TITLE
Fix "package loop for goblint-cil.makecfg" error on OCaml 4.08.1

### DIFF
--- a/src/ext/makecfg/META
+++ b/src/ext/makecfg/META
@@ -1,2 +1,1 @@
-requires = "goblint-cil.makecfg"
 description = "make the program look more like a CFG"


### PR DESCRIPTION
Under OCaml 4.08.1 on Ubuntu Linux 20.04.2 LTS, running `cilly` gives this error message:
```
$ cilly
No arguments passed
Usage: cilly [options] [gcc_or_mscl arguments]
...
  All other arguments starting with -- are passed to the Cilly process.

The following are the arguments of the Cilly process
Error: findlib: package loop for goblint-cil.makecfg.
Fatal error: exception Errormsg.Error
```

This patch fixes this problem.