### PR TITLE
Fix type of generated "!= " expression

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -4150,7 +4150,7 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
             let e' =
               let te = typeOf e in
               let _, zte = castTo intType te zero in
-              BinOp(Ne, e, zte, te)
+              BinOp(Ne, e, zte, intType)
             in
             finishExp se e' intType
         | _ ->

--- a/test/small1/land_expr.c
+++ b/test/small1/land_expr.c
@@ -1,0 +1,7 @@
+int main (int argc, char* argv[])
+{
+    signed char a = 7;
+    signed char b = 1;
+    b =  (1 && a) ;
+    return 0;
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -375,6 +375,8 @@ addTest("testrun/scope11 ");
 addTest("test/scope12 ");
 addTest("test/voidstar");
 addTest("testrun/memcpy1");
+addTest("testrun/land_expr");
+
 
 addTest("test/noreturn ");
 


### PR DESCRIPTION
This PR fixes issue #29. The "Ne"-expression that is generated is changed to have int-type, as it should.