### PR TITLE
Add column to location

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -878,6 +878,7 @@ and location = {
     line: int;		   (** The line number. -1 means "do not know" *)
     file: string;          (** The name of the source file*)
     byte: int;             (** The byte position in the source file *)
+    lineoffset: int;       (** The line offset *)
 }
 
 (* Type signatures. Two types are identical iff they have identical
@@ -892,7 +893,8 @@ and typsig =
 
 let locUnknown = { line = -1;
 		   file = "";
-		   byte = -1;}
+		   byte = -1;
+       lineoffset = -1}
 
 (* A reference to the current location *)
 let currentLoc : location ref = ref locUnknown
@@ -3289,7 +3291,8 @@ let initMsvcBuiltins () : unit =
 (** This is used as the location of the prototypes of builtin functions. *)
 let builtinLoc: location = { line = 1;
                              file = "<compiler builtins>";
-                             byte = 0;}
+                             byte = 0;
+                             lineoffset = 0}
 
 
 

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -878,7 +878,7 @@ and location = {
     line: int;		   (** The line number. -1 means "do not know" *)
     file: string;          (** The name of the source file*)
     byte: int;             (** The byte position in the source file *)
-    lineoffset: int;       (** The line offset *)
+    column: int;           (** The column number *)
 }
 
 (* Type signatures. Two types are identical iff they have identical
@@ -894,7 +894,7 @@ and typsig =
 let locUnknown = { line = -1;
 		   file = "";
 		   byte = -1;
-       lineoffset = -1}
+       column = -1}
 
 (* A reference to the current location *)
 let currentLoc : location ref = ref locUnknown
@@ -3292,7 +3292,7 @@ let initMsvcBuiltins () : unit =
 let builtinLoc: location = { line = 1;
                              file = "<compiler builtins>";
                              byte = 0;
-                             lineoffset = 0}
+                             column = 0}
 
 
 

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -911,7 +911,11 @@ let compareLoc (a: location) (b: location) : int =
     let linecmp = a.line - b.line in
     if linecmp != 0
     then linecmp
-    else a.byte - b.byte
+    else
+      let columncmp = a.column - b.column in
+      if columncmp != 0
+      then columncmp
+      else a.byte - b.byte
 
 let argsToList : (string * typ * attributes) list option
                   -> (string * typ * attributes) list

--- a/src/cil.mli
+++ b/src/cil.mli
@@ -1112,7 +1112,7 @@ and location = {
     line: int;		   (** The line number. -1 means "do not know" *)
     file: string;          (** The name of the source file*)
     byte: int;             (** The byte position in the source file *)
-    lineoffset: int;       (** The line offset *)
+    column: int;           (** The column number *)
 }
 
 

--- a/src/cil.mli
+++ b/src/cil.mli
@@ -1112,6 +1112,7 @@ and location = {
     line: int;		   (** The line number. -1 means "do not know" *)
     file: string;          (** The name of the source file*)
     byte: int;             (** The byte position in the source file *)
+    lineoffset: int;       (** The line offset *)
 }
 
 

--- a/src/ext/syntacticsearch/funcFunction.ml
+++ b/src/ext/syntacticsearch/funcFunction.ml
@@ -215,7 +215,7 @@ let find_uses_in_fun_all funstrucname file =
             Some (find_uses_in_fun "" fundec.svar.vid funstrucname file)))
        file.globals
 
-let loc_default = { line = -1; file = ""; byte = -1 }
+let loc_default = { line = -1; file = ""; byte = -1; lineoffset = -1 }
 
 class fun_find_usesvar_in_fun fundec funstrucname varname varid file result :
   nopCilVisitor =

--- a/src/ext/syntacticsearch/funcFunction.ml
+++ b/src/ext/syntacticsearch/funcFunction.ml
@@ -215,7 +215,7 @@ let find_uses_in_fun_all funstrucname file =
             Some (find_uses_in_fun "" fundec.svar.vid funstrucname file)))
        file.globals
 
-let loc_default = { line = -1; file = ""; byte = -1; lineoffset = -1 }
+let loc_default = { line = -1; file = ""; byte = -1; column = -1 }
 
 class fun_find_usesvar_in_fun fundec funstrucname varname varid file result :
   nopCilVisitor =

--- a/src/ext/syntacticsearch/queryMapping.ml
+++ b/src/ext/syntacticsearch/queryMapping.ml
@@ -2,7 +2,7 @@ open Cil
 open CodeQuery
 
 (* Default output if the input-query is not supported *)
-let loc_default = { line = -1; file = ""; byte = -1; lineoffset = -1 }
+let loc_default = { line = -1; file = ""; byte = -1; column = -1 }
 
 let rec delete_elem (name1, loc1, typ1, id1) list =
   match list with

--- a/src/ext/syntacticsearch/queryMapping.ml
+++ b/src/ext/syntacticsearch/queryMapping.ml
@@ -2,7 +2,7 @@ open Cil
 open CodeQuery
 
 (* Default output if the input-query is not supported *)
-let loc_default = { line = -1; file = ""; byte = -1 }
+let loc_default = { line = -1; file = ""; byte = -1; lineoffset = -1 }
 
 let rec delete_elem (name1, loc1, typ1, id1) list =
   match list with

--- a/src/ext/syntacticsearch/queryMapping.ml
+++ b/src/ext/syntacticsearch/queryMapping.ml
@@ -9,7 +9,7 @@ let rec delete_elem (name1, loc1, typ1, id1) list =
   | (name2, loc2, typ2, id2) :: xs ->
       if
         String.compare name1 name2 = 0
-        && loc1.line = loc2.line && loc1.byte = loc2.byte
+        && loc1.line = loc2.line && loc1.byte = loc2.byte && loc1.column = loc2.column
         && String.compare loc1.file loc2.file = 0
         && String.compare typ1 typ2 = 0
         && id1 = id2

--- a/src/ext/zrapp/zrapp.ml
+++ b/src/ext/zrapp/zrapp.ml
@@ -57,6 +57,10 @@ let loc_comp l1 l2 =
   then Some(1)
   else if l2.A.byteno > l1.A.byteno
   then Some(-1)
+  else if l1.A.columnno > l2.A.columnno
+  then Some(1)
+  else if l2.A.columnno > l1.A.columnno
+  then Some(-1)
   else Some(0)
 
 let simpleGaSearch l =

--- a/src/ext/zrapp/zrapp.ml
+++ b/src/ext/zrapp/zrapp.ml
@@ -78,6 +78,7 @@ let get_comments l =
   let cabsl = {A.lineno = l.line;
 	       A.filename = l.file;
 	       A.byteno = l.byte;
+         A.lineoffset = l.lineoffset;
 	       A.ident = 0;} in
   let s = simpleGaSearch cabsl in
 

--- a/src/ext/zrapp/zrapp.ml
+++ b/src/ext/zrapp/zrapp.ml
@@ -78,7 +78,7 @@ let get_comments l =
   let cabsl = {A.lineno = l.line;
 	       A.filename = l.file;
 	       A.byteno = l.byte;
-         A.lineoffset = l.lineoffset;
+         A.columnno = l.column;
 	       A.ident = 0;} in
   let s = simpleGaSearch cabsl in
 

--- a/src/frontc/cabs.ml
+++ b/src/frontc/cabs.ml
@@ -50,6 +50,7 @@ type cabsloc = {
  lineno : int;
  filename: string;
  byteno: int;
+ lineoffset: int;
  ident : int;
 }
 

--- a/src/frontc/cabs.ml
+++ b/src/frontc/cabs.ml
@@ -50,7 +50,7 @@ type cabsloc = {
  lineno : int;
  filename: string;
  byteno: int;
- lineoffset: int;
+ columnno: int;
  ident : int;
 }
 

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -124,7 +124,7 @@ let attrsForCombinedArg: ((string, string) H.t ->
 let lu = locUnknown
 let cabslu = {lineno = -10;
 	      filename = "cabs lu";
-	      byteno = -10;
+	      byteno = -10; lineoffset = -10;
               ident = 0;}
 
 
@@ -195,7 +195,7 @@ let debugLoc = false
 let convLoc (l : cabsloc) =
   if debugLoc then
     ignore (E.log "convLoc at %s: line %d, byte %d\n" l.filename l.lineno l.byteno);
-  {line = l.lineno; file = l.filename; byte = l.byteno;}
+  {line = l.lineno; file = l.filename; byte = l.byteno; lineoffset = l.lineoffset}
 
 
 let isOldStyleVarArgName n =

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -124,7 +124,7 @@ let attrsForCombinedArg: ((string, string) H.t ->
 let lu = locUnknown
 let cabslu = {lineno = -10;
 	      filename = "cabs lu";
-	      byteno = -10; lineoffset = -10;
+	      byteno = -10; columnno = -10;
               ident = 0;}
 
 
@@ -195,7 +195,7 @@ let debugLoc = false
 let convLoc (l : cabsloc) =
   if debugLoc then
     ignore (E.log "convLoc at %s: line %d, byte %d\n" l.filename l.lineno l.byteno);
-  {line = l.lineno; file = l.filename; byte = l.byteno; lineoffset = l.lineoffset}
+  {line = l.lineno; file = l.filename; byte = l.byteno; column = l.columnno}
 
 
 let isOldStyleVarArgName n =

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -194,7 +194,7 @@ let transparentUnionArgs : (int * typ) list ref = ref []
 let debugLoc = false
 let convLoc (l : cabsloc) =
   if debugLoc then
-    ignore (E.log "convLoc at %s: line %d, byte %d\n" l.filename l.lineno l.byteno);
+    ignore (E.log "convLoc at %s: line %d, byte %d, column %d\n" l.filename l.lineno l.byteno l.columnno);
   {line = l.lineno; file = l.filename; byte = l.byteno; column = l.columnno}
 
 

--- a/src/frontc/cabshelper.ml
+++ b/src/frontc/cabshelper.ml
@@ -11,11 +11,12 @@ let currentLoc () =
   { lineno   = l;
     filename = f;
     byteno   = c;
+    lineoffset = c - lc;
     ident    = getident ();}
 
 let cabslu = {lineno = -10; 
 	      filename = "cabs loc unknown"; 
-	      byteno = -10;
+	      byteno = -10; lineoffset = -10;
               ident = 0}
 
 (* clexer puts comments here *)

--- a/src/frontc/cabshelper.ml
+++ b/src/frontc/cabshelper.ml
@@ -11,12 +11,12 @@ let currentLoc () =
   { lineno   = l;
     filename = f;
     byteno   = c;
-    lineoffset = c - lc;
+    columnno = c - lc;
     ident    = getident ();}
 
 let cabslu = {lineno = -10; 
 	      filename = "cabs loc unknown"; 
-	      byteno = -10; lineoffset = -10;
+	      byteno = -10; columnno = -10;
               ident = 0}
 
 (* clexer puts comments here *)

--- a/src/frontc/cabshelper.ml
+++ b/src/frontc/cabshelper.ml
@@ -7,9 +7,9 @@ let getident () =
     !nextident
 
 let currentLoc () = 
-  let l, f, c = Errormsg.getPosition () in
-  { lineno   = l; 
-    filename = f; 
+  let l, f, c, lc = Errormsg.getPosition () in
+  { lineno   = l;
+    filename = f;
     byteno   = c;
     ident    = getident ();}
 

--- a/src/frontc/cabsvisit.ml
+++ b/src/frontc/cabsvisit.ml
@@ -93,7 +93,7 @@ end
 
 let visitorLocation = ref { filename = "";
 			    lineno = -1;
-			    byteno = -1; lineoffset = -1;
+			    byteno = -1; columnno = -1;
                             ident = 0}
 
         (* a default visitor which does nothing to the tree *)

--- a/src/frontc/cabsvisit.ml
+++ b/src/frontc/cabsvisit.ml
@@ -93,7 +93,7 @@ end
 
 let visitorLocation = ref { filename = "";
 			    lineno = -1;
-			    byteno = -1;
+			    byteno = -1; lineoffset = -1;
                             ident = 0}
 
         (* a default visitor which does nothing to the tree *)

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -63,7 +63,7 @@ let getComments () =
 
 let cabslu = {lineno = -10;
 	      filename = "cabs loc unknown";
-	      byteno = -10;
+	      byteno = -10; lineoffset = -10;
               ident = 0;}
 
 (* cabsloc -> cabsloc *)

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -63,7 +63,7 @@ let getComments () =
 
 let cabslu = {lineno = -10;
 	      filename = "cabs loc unknown";
-	      byteno = -10; lineoffset = -10;
+	      byteno = -10; columnno = -10;
               ident = 0;}
 
 (* cabsloc -> cabsloc *)

--- a/src/frontc/cprint.ml
+++ b/src/frontc/cprint.ml
@@ -69,7 +69,7 @@ type loc = { line : int; file : string }
 let lu = {line = -1; file = "loc unknown";}
 let cabslu = {lineno = -10;
 	      filename = "cabs loc unknown";
-	      byteno = -10; lineoffset = -10;
+	      byteno = -10; columnno = -10;
               ident = 0;}
 
 let curLoc = ref cabslu

--- a/src/frontc/cprint.ml
+++ b/src/frontc/cprint.ml
@@ -69,7 +69,7 @@ type loc = { line : int; file : string }
 let lu = {line = -1; file = "loc unknown";}
 let cabslu = {lineno = -10;
 	      filename = "cabs loc unknown";
-	      byteno = -10;
+	      byteno = -10; lineoffset = -10;
               ident = 0;}
 
 let curLoc = ref cabslu

--- a/src/ocamlutil/errormsg.ml
+++ b/src/ocamlutil/errormsg.ml
@@ -330,10 +330,10 @@ let parse_error (msg: string) : 'a =
 
 
 
-(* More parsing support functions: line, file, char count *)
-let getPosition () : int * string * int =
+(* More parsing support functions: line, file, char count, current line start char count *)
+let getPosition () : int * string * int * int =
   let i = !current in
-  i.linenum, i.fileName, Lexing.lexeme_start i.lexbuf
+  i.linenum, i.fileName, Lexing.lexeme_start i.lexbuf, i.linestart
 
 
 let getHPosition () =
@@ -358,6 +358,6 @@ let locUnknown = { file = ""; hfile = ""; line = -1; hline = -1 }
 
 let getLocation () =
   let hl, hf = getHPosition () in
-  let l, f, c = getPosition () in
+  let l, f, c, lc = getPosition () in
   { hfile = hf; hline = hl;
     file = f; line = l }

--- a/src/ocamlutil/errormsg.ml
+++ b/src/ocamlutil/errormsg.ml
@@ -330,7 +330,7 @@ let parse_error (msg: string) : 'a =
 
 
 
-(* More parsing support functions: line, file, char count, current line start char count *)
+(* More parsing support functions: line, file, char count, char count for line start *)
 let getPosition () : int * string * int * int =
   let i = !current in
   i.linenum, i.fileName, Lexing.lexeme_start i.lexbuf, i.linestart

--- a/src/ocamlutil/errormsg.mli
+++ b/src/ocamlutil/errormsg.mli
@@ -126,8 +126,9 @@ val withContext  : (unit -> Pretty.doc) -> ('a -> 'b) -> 'a -> 'b
 val newline: unit -> unit  (* Call this function to announce a new line *)
 val newHline: unit -> unit 
 
-val getPosition: unit -> int * string * int (* Line number, file name, 
-                                               current byte count in file *)
+val getPosition: unit -> int * string * int * int (* Line number, file name,
+                                                     current byte count in file,
+                                                     current line start byte count in file *)
 val getHPosition: unit -> int * string (** high-level position *)
 
 val setHLine: int -> unit

--- a/src/ocamlutil/errormsg.mli
+++ b/src/ocamlutil/errormsg.mli
@@ -128,7 +128,7 @@ val newHline: unit -> unit
 
 val getPosition: unit -> int * string * int * int (* Line number, file name,
                                                      current byte count in file,
-                                                     current line start byte count in file *)
+                                                     byte count for line start *)
 val getHPosition: unit -> int * string (** high-level position *)
 
 val setHLine: int -> unit


### PR DESCRIPTION
This would allow more precise locations in Goblint, particularly when multiple statements are on a single line.

### TODO
- [x] ~~Update `d_loc`?~~ Potentially breaks a lot of Goblint scripts that try to parse locations and what would even be the format?
- [x] Update `compareLoc` etc.
- [x] Update Goblint in parallel (https://github.com/goblint/analyzer/pull/295).