### PR TITLE
Add CFG fallthrough field to stmt

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -736,6 +736,7 @@ and stmt = {
                                            and the context in which this
                                            statement appears *)
     mutable preds: stmt list;          (** The inverse of the succs function*)
+    mutable fallthrough: stmt option;  (** The fallthrough successor statement computed from the context of this statement in {!Cil.computeCFGInto}. Useful for the syntactic successor of Goto and Loop. *)
   }
 
 (** Labels *)
@@ -1323,7 +1324,7 @@ let isSigned = function
 let mkStmt (sk: stmtkind) : stmt =
   { skind = sk;
     labels = [];
-    sid = -1; succs = []; preds = [] }
+    sid = -1; succs = []; preds = []; fallthrough = None }
 
 let mkBlock (slst: stmt list) : block =
   { battrs = []; bstmts = slst; }
@@ -6688,6 +6689,7 @@ let rec succpred_block b fallthrough rlabels =
 
 
 and succpred_stmt s fallthrough rlabels =
+  s.fallthrough <- fallthrough;
   match s.skind with
     Instr _ -> trylink s fallthrough
   | Return _ -> ()

--- a/src/cil.mli
+++ b/src/cil.mli
@@ -925,6 +925,8 @@ and stmt = {
      * the CFG is computed. *)
     mutable preds: stmt list;
     (** The inverse of the succs function. *)
+    mutable fallthrough: stmt option;
+    (** The fallthrough successor statement computed from the context of this statement in {!Cil.computeCFGInto}. Useful for the syntactic successor of Goto and Loop. *)
   }
 
 (** Labels *)


### PR DESCRIPTION
Consider the following program:
```c
f_empty_goto_loop_suffix_label:
  goto f_empty_goto_loop_suffix_label;

  suffix();
```

Here's the current CFG Goblint can construct using information by CIL on the left and the CFG you'd expect on the right:
| Actual | Expected |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/378740/127122004-08e25f6e-b201-4090-8b55-f133a57d5040.png) | ![image](https://user-images.githubusercontent.com/378740/127122129-f63732a0-c894-4fc7-b439-ec50c0bfb076.png) |

This is due to how successors of a `Goto` are computed in CIL:
https://github.com/goblint/cil/blob/208d2a2f9e51a42ee0a036f4587624ac7ac23ccb/src/cil.ml#L6690-L6694
Only the target of the goto is a successor, but the statement that comes after the goto (given from the context using the `fallthrough` argument) is completely ignored. This makes it completely impossible to know that `suffix()` comes after the goto in the source code. If this was exposed, Goblint could place the Neg(1) in a more intuitive way and not leave a weird out-of-thin-air node in the CFG.

An alternative could be to just add the fallthrough also into `succs` and have Goblint handle the two `succs` differently: like we already do with the successors of an `If`.
