### PR TITLE
add support for `__int128`, `__int128_t`, `__uint128_t`

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -2039,7 +2039,7 @@ let intRank (ik:ikind) : int =
   | IInt | IUInt -> 3
   | ILong | IULong -> 4
   | ILongLong | IULongLong -> 5
-  | IInt128 | IUInt128 -> 6 (* ? *)
+  | IInt128 | IUInt128 -> 6
 
 (* Return the common integer kind of the two integer arguments, as
    defined in ISO C 6.3.1.8 ("Usual arithmetic conversions") *)
@@ -2226,7 +2226,7 @@ let rec alignOf_int t =
     | TInt((IInt|IUInt), _) -> !M.theMachine.M.alignof_int
     | TInt((ILong|IULong), _) -> !M.theMachine.M.alignof_long
     | TInt((ILongLong|IULongLong), _) -> !M.theMachine.M.alignof_longlong
-    | TInt((IInt128|IUInt128), _) -> 16 (* ? *)
+    | TInt((IInt128|IUInt128), _) -> 16 (* not generated since not all architectures support 128bit ints and the value should be the same for those that do *)
     | TEnum(ei, _) -> alignOf_int (TInt(ei.ekind, []))
     | TFloat(FFloat, _) -> !M.theMachine.M.alignof_float
     | TFloat(FDouble, _) -> !M.theMachine.M.alignof_double
@@ -2859,9 +2859,9 @@ let parseInt (str: string) : exp =
   (* The length of the suffix and a list of possible kinds. See ISO
   * 6.4.4.1 *)
   let hasSuffix = hasSuffix str in
-  let suffixlen, kinds = (* TODO check situation with __int128 *)
+  let suffixlen, kinds = (* 128bit constants are only supported if long long is also 128bit, so we can parse those as long long *)
     if hasSuffix "ULL" || hasSuffix "LLU" then
-      3, [IULongLong] (* ? [if !M.theMachine.M.sizeof_longlong = 16 then IUInt128 else IULongLong] *)
+      3, [IULongLong]
     else if hasSuffix "LL" then
       2, if octalhex then [ILongLong; IULongLong] else [ILongLong]
     else if hasSuffix "UL" || hasSuffix "LU" then
@@ -7270,7 +7270,7 @@ let convertInts (i1:int64) (ik1:ikind) (i2:int64) (ik2:ikind)
       | IInt | IUInt -> 3
       | ILong | IULong -> 4
       | ILongLong | IULongLong -> 5
-      | IInt128 | IUInt128 -> 6 (* ? *)
+      | IInt128 | IUInt128 -> 6
     in
     let r1 = rank ik1 in
     let r2 = rank ik2 in

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -293,6 +293,8 @@ and ikind =
   | ILongLong   (** [long long] (or [_int64] on Microsoft Visual C) *)
   | IULongLong  (** [unsigned long long] (or [unsigned _int64] on Microsoft
                     Visual C) *)
+  | IInt128     (** [__int128] *)
+  | IUInt128    (** [unsigned __int128] *)
 
 (** Various kinds of floating-point numbers*)
 and fkind =

--- a/src/cil.mli
+++ b/src/cil.mli
@@ -287,6 +287,8 @@ and ikind =
   | ILongLong   (** [long long] (or [_int64] on Microsoft Visual C) *)
   | IULongLong  (** [unsigned long long] (or [unsigned _int64] on Microsoft
                     Visual C) *)
+  | IInt128     (** [__int128] *)
+  | IUInt128    (** [unsigned __int128] *)
 
 (** Various kinds of floating-point numbers*)
 and fkind =

--- a/src/ciltools.ml
+++ b/src/ciltools.ml
@@ -59,6 +59,7 @@ let ocaml_int_to_cil v n s =
   let short_size = bitsSizeOf (TInt(IShort,[]))in
   let long_size = bitsSizeOf longType in
   let longlong_size = bitsSizeOf (TInt(ILongLong,[])) in
+  let int128_size = bitsSizeOf (TInt(IInt128,[])) in
   let i =
     match s with
       Signed ->
@@ -72,6 +73,8 @@ let ocaml_int_to_cil v n s =
 	  ILong
 	else if (n = longlong_size) then
 	  ILongLong
+	else if (n = int128_size) then
+	  IInt128
 	else
 	  raise Weird_bitwidth
     | Unsigned ->
@@ -85,6 +88,8 @@ let ocaml_int_to_cil v n s =
 	  IULong
 	else if (n = longlong_size) then
 	  IULongLong
+	else if (n = int128_size) then
+	  IUInt128
 	else
 	  raise Weird_bitwidth
   in

--- a/src/formatparse.mly
+++ b/src/formatparse.mly
@@ -238,7 +238,7 @@ type maybeInit =
 %token EOF
 %token CHAR INT DOUBLE FLOAT VOID INT64 INT32
 %token ENUM STRUCT TYPEDEF UNION
-%token SIGNED UNSIGNED LONG SHORT
+%token SIGNED UNSIGNED LONG SHORT INT128
 %token VOLATILE EXTERN STATIC CONST RESTRICT AUTO REGISTER
 
 %token <string> ARG_e ARG_eo ARG_E ARG_u ARG_b ARG_t ARG_d ARG_lo ARG_l ARG_i
@@ -815,6 +815,15 @@ type_spec:
 |   UNSIGNED LONG LONG    { ((fun al args -> TInt(IULongLong, al)),
 
                              matchIntType IULongLong)
+                           }
+
+|   INT128          { ((fun al args -> TInt(IInt128, al)),
+
+                          matchIntType IInt128)
+                        }
+|   UNSIGNED INT128    { ((fun al args -> TInt(IUInt128, al)),
+
+                             matchIntType IUInt128)
                            }
 
 |   FLOAT           { ((fun al args -> TFloat(FFloat, al)),

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -250,7 +250,7 @@ let interpret_character_constant char_list =
     if value <= (Int64.of_int32 Int32.max_int) then
       (CInt64(value,IULong,orig_rep)),(TInt(IULong,[]))
     else
-      (CInt64(value,IULongLong,orig_rep)),(TInt(IULongLong,[])) (* TODO no need to handle __int128? *)
+      (CInt64(value,IULongLong,orig_rep)),(TInt(IULongLong,[])) (* 128bit constants are only supported if long long is also 128bit wide *)
   end
 
 (*** EXPRESSIONS *************)
@@ -2554,9 +2554,7 @@ let rec doSpecList (suggestedAnonName: string) (* This string will be part of
 	    else if fitsInInt ILong i then ILong
 	    else if fitsInInt IULong i then IULong
 	    else if fitsInInt ILongLong i then ILongLong
-	    else if fitsInInt IInt128 i then IInt128
-	    else if fitsInInt IUInt128 i then IUInt128
-	    else IULongLong (* TODO warn, use IUInt128? *)
+	    else IULongLong (* assume there can be not enum constants that don't fit in long long since there can only be 128bit constants if long long is also 128bit *)
 	in
         (* as each name,value pair is determined, this is called *)
         let rec processName kname (i: exp) loc rest = begin

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -250,7 +250,7 @@ let interpret_character_constant char_list =
     if value <= (Int64.of_int32 Int32.max_int) then
       (CInt64(value,IULong,orig_rep)),(TInt(IULong,[]))
     else
-      (CInt64(value,IULongLong,orig_rep)),(TInt(IULongLong,[]))
+      (CInt64(value,IULongLong,orig_rep)),(TInt(IULongLong,[])) (* TODO no need to handle __int128? *)
   end
 
 (*** EXPRESSIONS *************)
@@ -2554,7 +2554,9 @@ let rec doSpecList (suggestedAnonName: string) (* This string will be part of
 	    else if fitsInInt ILong i then ILong
 	    else if fitsInInt IULong i then IULong
 	    else if fitsInInt ILongLong i then ILongLong
-	    else IULongLong
+	    else if fitsInInt IInt128 i then IInt128
+	    else if fitsInInt IUInt128 i then IUInt128
+	    else IULongLong (* TODO warn, use IUInt128? *)
 	in
         (* as each name,value pair is determined, this is called *)
         let rec processName kname (i: exp) loc rest = begin

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -2382,9 +2382,10 @@ let rec doSpecList (suggestedAnonName: string) (* This string will be part of
       | A.Tlong -> 5
       | A.Tint -> 6
       | A.Tint64 -> 7
-      | A.Tfloat -> 8
-      | A.Tdouble -> 9
-      | _ -> 10 (* There should be at most one of the others *)
+      | A.Tint128 -> 8
+      | A.Tfloat -> 9
+      | A.Tdouble -> 10
+      | _ -> 11 (* There should be at most one of the others *)
     in
     List.stable_sort (fun ts1 ts2 -> compare (order ts1) (order ts2)) tspecs'
   in
@@ -2450,6 +2451,11 @@ let rec doSpecList (suggestedAnonName: string) (* This string will be part of
     | [A.Tsigned; A.Tint64] -> TInt(ILongLong, [])
 
     | [A.Tunsigned; A.Tint64] -> TInt(IULongLong, [])
+
+    | [A.Tint128]
+    | [A.Tsigned; A.Tint128] -> TInt(IInt128, [])
+
+    | [A.Tunsigned; A.Tint128] -> TInt(IUInt128, [])
 
     | [A.Tfloat] -> TFloat(FFloat, [])
     | [A.Tdouble] -> TFloat(FDouble, [])

--- a/src/frontc/clexer.mll
+++ b/src/frontc/clexer.mll
@@ -279,6 +279,9 @@ let init ~(filename: string) : Lexing.lexbuf =
   init_lexicon ();
   (* Inititialize the pointer in Errormsg *)
   Lexerhack.add_type := add_type;
+  (* add some built-in types which are handled as Tnamed in cabs2cil *)
+  add_type "__int128_t"; (* __int128 *)
+  add_type "__uint128_t"; (* unsigned __int128 *)
   Lexerhack.push_context := push_context;
   Lexerhack.pop_context := pop_context;
   Lexerhack.add_identifier := add_identifier;

--- a/src/frontc/frontc.ml
+++ b/src/frontc/frontc.ml
@@ -187,6 +187,7 @@ and parse_to_cabs_inner (fname : string) =
   try
     if !E.verboseFlag then ignore (E.log "Frontc is parsing %s\n" fname);
     flush !E.logChannel;
+    (* if !E.verboseFlag then ignore @@ Parsing.set_trace true; *)
     let lexbuf = Clexer.init ~filename:fname in
     let cabs = Stats.time "parse" (Cparser.interpret (Whitetrack.wraplexer clexer)) lexbuf in
     Whitetrack.setFinalWhite (Clexer.get_white ());

--- a/src/frontc/frontc.ml
+++ b/src/frontc/frontc.ml
@@ -202,7 +202,9 @@ and parse_to_cabs_inner (fname : string) =
       ignore (E.log "Parsing error");
       Clexer.finish ();
       close_output ();
-      raise (ParseError("Parse error"))
+      (* raise (ParseError("Parse error")) *)
+      let backtrace = Printexc.get_raw_backtrace () in
+      Printexc.raise_with_backtrace (ParseError("Parse error")) backtrace (* re-raise with captured inner backtrace *)
   end
   | e -> begin
       ignore (E.log "Caught %s while parsing\n" (Printexc.to_string e));


### PR DESCRIPTION
Closes #41.
I left some TODOs where I wasn't sure.
Esp. if `long long` is already 128 bit on the machine, do we then want `ikind` `ILongLong` or `IInt128`?

(This machine-dependent ambiguity is a source of errors if one does not use CIL's functions but assumes e.g. `long long` to be of a certain size - might be better to let CIL just emit concrete int sizes like `int32_t`.)