### PR TITLE
Use `Cilint` in `CInt64`

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -9,4 +9,4 @@ B _build/src/ext/
 B _build/src/ext/pta/
 B _build/src/frontc/
 B _build/src/ocamlutil/
-PKG findlib
+PKG findlib, zarith

--- a/src/check.ml
+++ b/src/check.ml
@@ -641,8 +641,8 @@ and checkInit  (i: init) : typ =
                 match elen with
                 | None -> 0L
                 | Some e -> (ignore (checkExp true e);
-                match isInteger (constFold true e) with
-                  Some len -> len
+                match getInteger (constFold true e) with
+                  Some len -> Z.to_int64 len (* Z on purpose, we don;t want to ingore overflows here *)
                 | None ->
                     ignore (warn "Array length is not a constant");
                     0L)
@@ -653,9 +653,9 @@ and checkInit  (i: init) : typ =
                       ignore (warn "Wrong number of initializers in array")
 
                 | (Index(Const(CInt64(i', _, _)), NoOffset), ei) :: rest ->
-                    if i' <> i then
+                    if Int64.compare (Z.to_int64 i') i <> 0 then
                       ignore (warn "Initializer for index %s when %s was expected"
-                                (Int64.format "%d" i') (Int64.format "%d" i));
+                                (Int64.format "%d" (Z.to_int64 i')) (Int64.format "%d" i));
                     checkInitType ei bt;
                     loopIndex (Int64.succ i) rest
                 | _ :: rest ->

--- a/src/check.ml
+++ b/src/check.ml
@@ -642,7 +642,7 @@ and checkInit  (i: init) : typ =
                 | None -> 0L
                 | Some e -> (ignore (checkExp true e);
                 match getInteger (constFold true e) with
-                  Some len -> Z.to_int64 len (* Z on purpose, we don;t want to ingore overflows here *)
+                  Some len -> Z.to_int64 len (* Z on purpose, we don't want to ignore overflows here *)
                 | None ->
                     ignore (warn "Array length is not a constant");
                     0L)

--- a/src/check.ml
+++ b/src/check.ml
@@ -652,7 +652,7 @@ and checkInit  (i: init) : typ =
                     if i > len then
                       ignore (warn "Wrong number of initializers in array")
 
-                | (Index(Const(CInt64(i', _, _)), NoOffset), ei) :: rest ->
+                | (Index(Const(CInt(i', _, _)), NoOffset), ei) :: rest ->
                     if Int64.compare (Z.to_int64 i') i <> 0 then
                       ignore (warn "Initializer for index %s when %s was expected"
                                 (Int64.format "%d" (Z.to_int64 i')) (Int64.format "%d" i));

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -2768,14 +2768,13 @@ let parseInt (str: string) : exp =
    * POSITIVE  *)
   let res =
     let rec loop = function
-        k::rest ->
-	  if fitsInInt k i then kintegerCilint k i
-	  else loop rest
-        | [] -> E.s (E.unimp "Cannot represent the integer %s\n"
-                       (string_of_cilint i))
+      | k::rest ->
+        if fitsInInt k i then kintegerCilint k i
+        else loop rest
+      | [] -> E.s (E.unimp "Cannot represent the integer %s\n" (string_of_cilint i))
     in
     loop kinds
-    in
+  in
   res
 (* with e -> begin *)
 (*   ignore (E.log "int_of_string %s (%s)\n" str  *)

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -2699,11 +2699,10 @@ and isConstantOffset = function
   | Index(e, off) -> isConstant e && isConstantOffset off
 
 let parseInt (str: string) : exp =
-  let hasSuffix str =
+  let hasSuffix str suff =
     let l = String.length str in
-    fun s ->
-      let ls = String.length s in
-      l >= ls && s = String.uppercase_ascii (String.sub str (l - ls) ls)
+    let lsuff = String.length suff in
+    l >= lsuff && suff = String.uppercase_ascii (String.sub str (l - lsuff) lsuff)
   in
   let l = String.length str in
   (* See if it is octal or hex *)
@@ -2747,17 +2746,11 @@ let parseInt (str: string) : exp =
   let t = String.sub str start (String.length str - start - suffixlen) in
   (* Normal Z.of_string does not work here as 0 is not recognized as the prefix for octal here *)
   let i = Z.of_string_base base t in
-  (* Construct an integer of the first kinds that fits. i must be POSITIVE  *)
-  let res =
-    let rec loop = function
-      | k::rest ->
-        if fitsInInt k i then kintegerCilintString k i (Some str)
-        else loop rest
-      | [] -> E.s (E.unimp "Cannot represent the integer %s\n" (string_of_cilint i))
-    in
-    loop kinds
-  in
-  res
+  try
+    (* Construct an integer of the first kinds that fits. i must be POSITIVE  *)
+    let ik = List.find (fun ik -> fitsInInt ik i) kinds in
+    kintegerCilintString ik i (Some str)
+  with Not_found -> E.s (E.unimp "Cannot represent the integer %s\n" (string_of_cilint i))
 
 
 let d_unop () u =

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -4598,7 +4598,7 @@ class plainCilPrinterClass =
         match c with
           CInt(i, ik, so) ->
 	    let fmt = if isSigned ik then "%d" else "%x" in
-            dprintf "Int64(%s,%a,%s)"
+            dprintf "Int(%s,%a,%s)"
               (Z.format fmt i)
               d_ikind ik
               (match so with Some s -> s | _ -> "None")

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -2747,8 +2747,7 @@ let parseInt (str: string) : exp =
   let t = String.sub str start (String.length str - start - suffixlen) in
   (* Normal Z.of_string does not work here as 0 is not recognized as the prefix for octal here *)
   let i = Z.of_string_base base t in
-  (* Construct an integer of the first kinds that fits. i must be
-   * POSITIVE  *)
+  (* Construct an integer of the first kinds that fits. i must be POSITIVE  *)
   let res =
     let rec loop = function
       | k::rest ->
@@ -2759,12 +2758,6 @@ let parseInt (str: string) : exp =
     loop kinds
   in
   res
-(* with e -> begin *)
-(*   ignore (E.log "int_of_string %s (%s)\n" str  *)
-(*             (Printexc.to_string e)); *)
-(*     zero *)
-(*   end *)
-
 
 
 let d_unop () u =

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -2750,7 +2750,8 @@ let parseInt (str: string) : exp =
     (* Construct an integer of the first kinds that fits. i must be POSITIVE  *)
     let ik = List.find (fun ik -> fitsInInt ik i) kinds in
     kintegerCilintString ik i (Some str)
-  with Not_found -> E.s (E.unimp "Cannot represent the integer %s\n" (string_of_cilint i))
+  with Not_found ->
+    E.s (E.unimp "Cannot represent the integer %s\n" (string_of_cilint i))
 
 
 let d_unop () u =

--- a/src/cil.mli
+++ b/src/cil.mli
@@ -635,7 +635,7 @@ and exp =
 
 (** Literal constants *)
 and constant =
-  | CInt64 of cilint * ikind * string option
+  | CInt of cilint * ikind * string option
     (** Integer constant. Give the ikind (see ISO9899 6.1.3.2) and the
      * textual representation, if available. (This allows us to print a
      * constant as, for example, 0xF instead of 15.) Use {!Cil.integer} or
@@ -1647,7 +1647,7 @@ val isNullPtrConstant: exp -> bool
 (** Given the character c in a (CChr c), sign-extend it to 32 bits.
   (This is the official way of interpreting character constants, according to
   ISO C 6.4.4.4.10, which says that character constants are chars cast to ints)
-  Returns CInt64(sign-extended c, IInt, None) *)
+  Returns CInt(sign-extended c, IInt, None) *)
 val charConstToInt: char -> constant
 
 (** Do constant folding on an expression. If the first argument is true then
@@ -2565,7 +2565,7 @@ val fitsInInt: ikind -> cilint -> bool
 val intKindForValue: cilint -> bool -> ikind
 
 (** Construct a cilint from an integer kind and int64 value. Used for
- * getting the actual constant value from a CInt64(n, ik, _)
+ * getting the actual constant value from a CInt(n, ik, _)
  * constant. *)
 val mkCilint : ikind -> int64 -> cilint
 

--- a/src/cil.mli
+++ b/src/cil.mli
@@ -635,12 +635,11 @@ and exp =
 
 (** Literal constants *)
 and constant =
-  | CInt64 of int64 * ikind * string option
+  | CInt64 of cilint * ikind * string option
     (** Integer constant. Give the ikind (see ISO9899 6.1.3.2) and the
      * textual representation, if available. (This allows us to print a
      * constant as, for example, 0xF instead of 15.) Use {!Cil.integer} or
-     * {!Cil.kinteger} to create these. Watch out for integers that cannot be
-     * represented on 64 bits. OCAML does not give Overflow exceptions. *)
+     * {!Cil.kinteger} to create these. *)
   | CStr of string
     (** String constant. The escape characters inside the string have been
      * already interpreted. This constant has pointer to character type! The
@@ -1110,7 +1109,7 @@ and location = {
  * the formal arguments are given the same signature. Also, [TNamed]
  * constructors are unrolled. *)
 and typsig =
-    TSArray of typsig * int64 option * attribute list
+    TSArray of typsig * cilint option * attribute list
   | TSPtr of typsig * attribute list
   | TSComp of bool * string * attribute list
   | TSFun of typsig * typsig list option * bool * attribute list
@@ -2570,6 +2569,8 @@ val intKindForValue: cilint -> bool -> ikind
  * constant. *)
 val mkCilint : ikind -> int64 -> cilint
 
+val mkCilintIk : ikind -> cilint -> cilint
+
 (** The size of a type, in bytes. Returns a constant expression or a
  * "sizeof" expression if it cannot compute the size. This function
  * is architecture dependent, so you should only call this after you
@@ -2688,20 +2689,6 @@ val envMachine : Machdep.mach option ref
 (*                        These will eventually go away                      *)
 (* ------------------------------------------------------------------------- *)
 
-(** @deprecated. Convert two int64/kind pairs to a common int64/int64/kind triple. *)
-val convertInts: int64 -> ikind -> int64 -> ikind -> int64 * int64 * ikind
-
-(** @deprecated. Can't handle large 64-bit unsigned constants
-    correctly - use getInteger instead. If the given expression
-    is a (possibly cast'ed) character or an integer constant, return
-    that integer.  Otherwise, return None. *)
-val isInteger: exp -> int64 option
-
-(** @deprecated. Use truncateCilint instead. Represents an integer as
- * for a given kind.  Returns a flag saying whether the value was
- * changed during truncation (because it was too large to fit in k). *)
-val truncateInteger64: ikind -> int64 -> int64 * bool
-
-(** @deprecated.  For compatibility with older programs, these are
-    aliases for {!Cil.builtinFunctions} *)
+(** @deprecated.  For compatibility with older programs, this is an
+    alias for {!Cil.builtinFunctions} *)
 val gccBuiltins: (string, typ * typ list * bool) Hashtbl.t

--- a/src/cilint.ml
+++ b/src/cilint.ml
@@ -19,6 +19,7 @@ type truncation = NoTruncation | ValueTruncation | BitTruncation
 
 let zero_cilint = zero_big_int
 let one_cilint = unit_big_int
+let mone_cilint = minus_big_int unit_big_int
 
 (* Precompute useful big_ints *)
 let b30 = power_int_positive_int 2 30

--- a/src/cilint.ml
+++ b/src/cilint.ml
@@ -62,29 +62,29 @@ let cilint_of_int (i:int) : cilint = big_int_of_int i
 let int_of_cilint (c:cilint) : int = int_of_big_int c
 
 let cilint_of_int64 (i64:int64) : cilint =
-    (* We convert 30 bits at a time *)
-    let rec loop i mul acc =
-      if i = 0L then acc
-      else if i = -1L then sub_big_int acc mul
-      else
+  (* We convert 30 bits at a time *)
+  let rec loop i mul acc =
+    if i = 0L then acc
+    else if i = -1L then sub_big_int acc mul
+    else
 	let lo30 = Int64.to_int (Int64.logand i 0x3fffffffL) in
 	loop (Int64.shift_right i 30) (mult_big_int mul b30)
 	  (add_big_int acc (mult_big_int mul (big_int_of_int lo30)))
-    in (loop i64 unit_big_int zero_big_int)
+  in (loop i64 unit_big_int zero_big_int)
 
 (* Note that this never fails, instead it returns the low-order 64-bits
    of the cilint. *)
 let int64_of_cilint (b:cilint) : int64 =
-      let rec loop b mul acc =
-	if sign_big_int b = 0 then
-	  acc
-	else if compare_big_int b m1 == 0 then
-	  Int64.sub acc mul
-	else
-	  let hi, lo = quomod_big_int b b30 in
-	  loop hi (Int64.mul mul 0x40000000L)
-	    (Int64.add acc (Int64.mul mul (Int64.of_int (int_of_big_int lo))))
-      in loop b 1L 0L
+  let rec loop b mul acc =
+    if sign_big_int b = 0 then
+      acc
+    else if compare_big_int b m1 == 0 then
+      Int64.sub acc mul
+    else
+      let hi, lo = quomod_big_int b b30 in
+      loop hi (Int64.mul mul 0x40000000L)
+        (Int64.add acc (Int64.mul mul (Int64.of_int (int_of_big_int lo))))
+  in loop b 1L 0L
 
 let cilint_of_string (s:string) : cilint =
   cilint_of_big_int (big_int_of_string s)
@@ -93,16 +93,16 @@ let string_of_cilint (c:cilint) : string = string_of_big_int c
 
 (* Divide rounding towards zero *)
 let div0_cilint (c1:cilint) (c2:cilint) =
-      let b1 = big_int_of_cilint c1 in
-      let b2 = big_int_of_cilint c2 in
-      let q, r = quomod_big_int b1 b2 in
-      if lt_big_int b1 zero_big_int && (not (eq_big_int r zero_big_int)) then
-	if gt_big_int b2 zero_big_int then
-	  (succ_big_int q)
-	else
-	  (pred_big_int q)
-      else
-  q
+  let b1 = big_int_of_cilint c1 in
+  let b2 = big_int_of_cilint c2 in
+  let q, r = quomod_big_int b1 b2 in
+  if lt_big_int b1 zero_big_int && (not (eq_big_int r zero_big_int)) then
+    if gt_big_int b2 zero_big_int then
+      (succ_big_int q)
+    else
+      (pred_big_int q)
+  else
+    q
 
 (* And the corresponding remainder *)
 let rem_cilint (c1:cilint) (c2:cilint) =
@@ -111,24 +111,24 @@ let rem_cilint (c1:cilint) (c2:cilint) =
 (* Perform logical op 'op' over 'int' on two cilints. Does it work
    30-bits at a time as that is guaranteed to fit in an 'int'. *)
 let logop op c1 c2 =
-      let b1 = big_int_of_cilint c1 in
-      let b2 = big_int_of_cilint c2 in
-      let rec loop b1 b2 mul acc =
-	if nobits b1 && nobits b2 then
-	  (* Once we only have all-0/all-1 values left, we can find whether
-	     the infinite high-order bits are all-0 or all-1 by checking the
-	     behaviour of op on b1 and b2. *)
-	  if op (int_of_big_int b1) (int_of_big_int b2) = 0 then
-	    acc
-	  else
-	    sub_big_int acc mul
-	else
-	  let hi1, lo1 = quomod_big_int b1 b30 in
-	  let hi2, lo2 = quomod_big_int b2 b30 in
-	  let lo = op (int_of_big_int lo1) (int_of_big_int lo2) in
-	  loop hi1 hi2 (mult_big_int mul b30)
-	    (add_big_int acc (mult_big_int mul (big_int_of_int lo)))
-      in cilint_of_big_int (loop b1 b2 unit_big_int zero_big_int)
+  let b1 = big_int_of_cilint c1 in
+  let b2 = big_int_of_cilint c2 in
+  let rec loop b1 b2 mul acc =
+    if nobits b1 && nobits b2 then
+      (* Once we only have all-0/all-1 values left, we can find whether
+        the infinite high-order bits are all-0 or all-1 by checking the
+        behaviour of op on b1 and b2. *)
+      if op (int_of_big_int b1) (int_of_big_int b2) = 0 then
+        acc
+      else
+        sub_big_int acc mul
+    else
+      let hi1, lo1 = quomod_big_int b1 b30 in
+      let hi2, lo2 = quomod_big_int b2 b30 in
+      let lo = op (int_of_big_int lo1) (int_of_big_int lo2) in
+      loop hi1 hi2 (mult_big_int mul b30)
+        (add_big_int acc (mult_big_int mul (big_int_of_int lo)))
+  in cilint_of_big_int (loop b1 b2 unit_big_int zero_big_int)
 
 let logand_cilint = logop (land)
 let logor_cilint = logop (lor)
@@ -142,39 +142,40 @@ let shift_left_cilint (c1:cilint) (n:int) : cilint =
 let lognot_cilint (c1:cilint) : cilint = (pred_big_int (minus_big_int c1))
 
 let truncate_signed_cilint (c:cilint) (n:int) : cilint * truncation =
-      let b = big_int_of_cilint c in
-      let max = power_int_positive_int 2 (n - 1) in
-      let truncmax = power_int_positive_int 2 n in
-      let bits = mod_big_int b truncmax in
-      let tval =
-	if lt_big_int bits max then
-	  bits
-	else
-	  sub_big_int bits truncmax
-      in
-      let trunc =
-	if ge_big_int b max || lt_big_int b (minus_big_int max) then
-	  if ge_big_int b truncmax then
-	    BitTruncation
+  let b = big_int_of_cilint c in
+  let max = power_int_positive_int 2 (n - 1) in
+  let truncmax = power_int_positive_int 2 n in
+  let bits = mod_big_int b truncmax in
+  let tval = if lt_big_int bits max then
+	    bits
 	  else
-	    ValueTruncation
-	else
-	  NoTruncation
-      in cilint_of_big_int tval, trunc
+	    sub_big_int bits truncmax
+  in
+  let trunc =
+    if ge_big_int b max || lt_big_int b (minus_big_int max) then
+      if ge_big_int b truncmax then
+        BitTruncation
+      else
+        ValueTruncation
+    else
+      NoTruncation
+  in
+    cilint_of_big_int tval, trunc
 
 let truncate_unsigned_cilint (c:cilint) (n:int) : cilint * truncation =
-      let b = big_int_of_cilint c in
-      let max = power_int_positive_int 2 (n - 1) in
-      let truncmax = power_int_positive_int 2 n in
-      let bits = mod_big_int b truncmax in
-      let trunc =
-	if ge_big_int b truncmax || lt_big_int b zero_big_int then
-	  if lt_big_int b (minus_big_int max) then
-	    BitTruncation
+  let b = big_int_of_cilint c in
+  let max = power_int_positive_int 2 (n - 1) in
+  let truncmax = power_int_positive_int 2 n in
+  let bits = mod_big_int b truncmax in
+  let trunc =
+    if ge_big_int b truncmax || lt_big_int b zero_big_int then
+      if lt_big_int b (minus_big_int max) then
+        BitTruncation
+      else
+        ValueTruncation
 	  else
-	    ValueTruncation
-	else
-	  NoTruncation
-      in cilint_of_big_int bits, trunc
+	    NoTruncation
+  in
+  cilint_of_big_int bits, trunc
 
 let is_int_cilint (c:cilint) : bool = is_int_big_int c

--- a/src/cilint.mli
+++ b/src/cilint.mli
@@ -11,6 +11,9 @@ val zero_cilint : cilint
 (** 1 as a cilint *)
 val one_cilint : cilint
 
+(** -1 as a cilint *)
+val mone_cilint : cilint
+
 (** Result type for truncate_... functions *)
 type truncation = NoTruncation | ValueTruncation | BitTruncation
 

--- a/src/cilint.mli
+++ b/src/cilint.mli
@@ -3,7 +3,7 @@
 (** The cilint type is public and not just big_int to make life with ocamldebug
     easier. Please do not rely on this representation, use the ..._of_cilint
     functions to get at a cilint's value. *)
-type cilint = Small of int | Big of Big_int_Z.big_int
+type cilint = Big_int_Z.big_int
 
 (** 0 as a cilint *)
 val zero_cilint : cilint

--- a/src/ext/zrapp/rmciltmps.ml
+++ b/src/ext/zrapp/rmciltmps.ml
@@ -3,7 +3,7 @@
    others must wait until pretty printing *)
 
 open Cil
-
+open Cilint
 module E = Errormsg
 module RD = Reachingdefs
 module AELV = Availexpslv
@@ -287,15 +287,15 @@ let ok_to_replace_with_incdec curiosh defiosh f id vi r =
   let inc_or_dec e vi =
     match e with
       BinOp((PlusA|PlusPI|IndexPI), Lval(Var vi', NoOffset),
-	    Const(CInt64(one,_,_)),_) ->
-	      if vi.vid = vi'.vid && one = Int64.one
+	    Const(CInt64(a,_,_)),_) ->
+	      if vi.vid = vi'.vid && compare_cilint a one_cilint = 0
 	      then Some(PlusA)
-	      else if vi.vid = vi'.vid && one = Int64.minus_one
+	      else if vi.vid = vi'.vid && compare_cilint a mone_cilint = 0
 	      then Some(MinusA)
 	      else None
     | BinOp((MinusA|MinusPI), Lval(Var vi', NoOffset),
-	    Const(CInt64(one,_,_)),_) ->
-	      if vi.vid = vi'.vid && one = Int64.one
+	    Const(CInt64(a,_,_)),_) ->
+	      if vi.vid = vi'.vid && compare_cilint a one_cilint = 0
 	      then Some(MinusA)
 	      else None
     | _ -> None

--- a/src/ext/zrapp/rmciltmps.ml
+++ b/src/ext/zrapp/rmciltmps.ml
@@ -287,14 +287,14 @@ let ok_to_replace_with_incdec curiosh defiosh f id vi r =
   let inc_or_dec e vi =
     match e with
       BinOp((PlusA|PlusPI|IndexPI), Lval(Var vi', NoOffset),
-	    Const(CInt64(a,_,_)),_) ->
+	    Const(CInt(a,_,_)),_) ->
 	      if vi.vid = vi'.vid && compare_cilint a one_cilint = 0
 	      then Some(PlusA)
 	      else if vi.vid = vi'.vid && compare_cilint a mone_cilint = 0
 	      then Some(MinusA)
 	      else None
     | BinOp((MinusA|MinusPI), Lval(Var vi', NoOffset),
-	    Const(CInt64(a,_,_)),_) ->
+	    Const(CInt(a,_,_)),_) ->
 	      if vi.vid = vi'.vid && compare_cilint a one_cilint = 0
 	      then Some(MinusA)
 	      else None

--- a/src/formatparse.mly
+++ b/src/formatparse.mly
@@ -115,7 +115,7 @@ let rec checkSameFormat (fl1: formatArg list) (fl2: formatArg list) =
 
       and checkExpEq e1 e2 =
         match e1, e2 with
-          Const(CInt64(n1, _, _)), Const(CInt64(n2, _, _)) -> n1 = n2
+          Const(CInt(n1, _, _)), Const(CInt(n2, _, _)) -> n1 = n2
         | Lval l1, Lval l2 -> checkLvalEq l1 l2
         | UnOp(uo1, e1, _), UnOp(uo2, e2, _) ->
             uo1 = uo2 && checkExpEq e1 e2
@@ -551,7 +551,7 @@ constant:
                               | a -> wrongArgType currentArg "integer" a),
 
                             fun e -> match e with
-                              Const(CInt64(n, _, _)) ->
+                              Const(CInt(n, _, _)) ->
                                 Some [ Fd (Cilint.int_of_cilint n) ]
                             | _ -> None)
                          }
@@ -571,8 +571,8 @@ constant:
                            ((fun args -> n),
 
                             (fun e -> match e, n with
-                              Const(CInt64(e', _, _)),
-                              Const(CInt64(n', _, _)) when e' = n' -> Some []
+                              Const(CInt(e', _, _)),
+                              Const(CInt(n', _, _)) when e' = n' -> Some []
                             | _ -> None))
                          }
 ;

--- a/src/formatparse.mly
+++ b/src/formatparse.mly
@@ -552,7 +552,7 @@ constant:
 
                             fun e -> match e with
                               Const(CInt64(n, _, _)) ->
-                                Some [ Fd (Int64.to_int n) ]
+                                Some [ Fd (Cilint.int_of_cilint n) ]
                             | _ -> None)
                          }
 

--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -1247,7 +1247,7 @@ begin
     (
       (* CIL changes (unsigned)0 into 0U during printing.. *)
       match xc,yc with
-      | CInt64(0L,_,_),CInt64(0L,_,_) -> true  (* ok if they're both 0 *)
+      | CInt64(a,_,_),CInt64(b,_,_)  when Cilint.is_zero_cilint a && Cilint.is_zero_cilint b -> true  (* ok if they're both 0 *)
       | _,_ -> false
     )
   | Lval(xl), Lval(yl) ->          (equalLvals xl yl)

--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -506,7 +506,7 @@ let rec combineTypes (what: combineWhat)
         | Some oldsz', Some sz' ->
             let samesz =
               match constFold true oldsz', constFold true sz' with
-                Const(CInt64(oldi, _, _)), Const(CInt64(i, _, _)) -> oldi = i
+                Const(CInt(oldi, _, _)), Const(CInt(i, _, _)) -> oldi = i
               | _, _ -> false
             in
             if samesz then oldsz else
@@ -702,7 +702,7 @@ and matchEnumInfo (oldfidx: int) (oldei: enuminfo)
             raise (Failure "(different names for enumeration items)");
           let samev =
             match constFold true old_iv, constFold true iv with
-              Const(CInt64(oldi, _, _)), Const(CInt64(i, _, _)) -> oldi = i
+              Const(CInt(oldi, _, _)), Const(CInt(i, _, _)) -> oldi = i
             | _ -> false
           in
           if not samev then
@@ -1247,7 +1247,7 @@ begin
     (
       (* CIL changes (unsigned)0 into 0U during printing.. *)
       match xc,yc with
-      | CInt64(a,_,_),CInt64(b,_,_)  when Cilint.is_zero_cilint a && Cilint.is_zero_cilint b -> true  (* ok if they're both 0 *)
+      | CInt(a,_,_),CInt(b,_,_)  when Cilint.is_zero_cilint a && Cilint.is_zero_cilint b -> true  (* ok if they're both 0 *)
       | _,_ -> false
     )
   | Lval(xl), Lval(yl) ->          (equalLvals xl yl)

--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -506,7 +506,7 @@ let rec combineTypes (what: combineWhat)
         | Some oldsz', Some sz' ->
             let samesz =
               match constFold true oldsz', constFold true sz' with
-                Const(CInt(oldi, _, _)), Const(CInt(i, _, _)) -> oldi = i
+                Const(CInt(oldi, _, _)), Const(CInt(i, _, _)) -> Cilint.compare_cilint oldi i = 0
               | _, _ -> false
             in
             if samesz then oldsz else
@@ -702,7 +702,7 @@ and matchEnumInfo (oldfidx: int) (oldei: enuminfo)
             raise (Failure "(different names for enumeration items)");
           let samev =
             match constFold true old_iv, constFold true iv with
-              Const(CInt(oldi, _, _)), Const(CInt(i, _, _)) -> oldi = i
+              Const(CInt(oldi, _, _)), Const(CInt(i, _, _)) -> Cilint.compare_cilint oldi i = 0
             | _ -> false
           in
           if not samev then


### PR DESCRIPTION
- This replaces `int64 option` in `CInt64` with `cilint option`.
- Also `cilint` now does no longer do the case distinction between small numbers (that fit into `int`) and larger ones.
Instead it is a very thin wrapper around Zarith, that already does this internally.
- It also renames `CInt64`  to `CInt`.

This is currently against the `no_msvc` branch, but we can change base to `develop` once that is merged.

Closes #47 

