### PR TITLE
Change some errors to warnings for coreutils

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -2870,10 +2870,10 @@ and doType (nameortype: attributeClass) (* This is AttrName if we are doing
                        (cabsTypeAddAttributes a1f tf), ap)
           | _ ->
               if a1f <> [] && not a1fadded then
-                E.s (error "Invalid position for (prefix) function type attributes:%a"
+                ignore (warn "Invalid position for (prefix) function type attributes:%a"
                        d_attrlist a1f);
               if a2f <> [] then
-                E.s (error "Invalid position for (post) function type attributes:%a"
+                ignore (warn "Invalid position for (post) function type attributes:%a"
                        d_attrlist a2f);
               restyp
         in

--- a/src/frontc/cabshelper.ml
+++ b/src/frontc/cabshelper.ml
@@ -31,7 +31,10 @@ let joinLoc l1 l2 = match l1, l2 with
     {l1 with endLineno = l2.lineno; endByteno = l2.byteno; endColumnno = l2.columnno}
   | l1, l2 when l1.filename = l2.filename && l1.endByteno = l2.endByteno && l1.byteno = l2.byteno -> 
     l1 (* alias fundefs *)
-  | _, _ -> Errormsg.s (Errormsg.unimp "joinLoc %s %s" (string_of_loc l1) (string_of_loc l2))
+  | _, _ ->
+    (* some code generators leave start and end into different files: https://github.com/goblint/cil/issues/54 *)
+    Errormsg.warn "joinLoc %s %s" (string_of_loc l1) (string_of_loc l2);
+    l1 (* no way to give an actual range *)
 
 (* clexer puts comments here *)
 let commentsGA = GrowArray.make 100 (GrowArray.Elem(cabslu,"",false))


### PR DESCRIPTION
Closes #54. Subsumes #55 with attribute change as well.

If there are any more problems parsing some of the coreutils benchmarks, we can append their fixes here as well.