### PR TITLE
Ignore `clang` pragmas

### DIFF
--- a/src/frontc/clexer.mll
+++ b/src/frontc/clexer.mll
@@ -438,7 +438,7 @@ let oct_escape = '\\' octdigit octdigit? octdigit?
 
 (* Pragmas that are not parsed by CIL.  We lex them as PRAGMA_LINE tokens *)
 let no_parse_pragma =
-               "warning" | "GCC" | "STDC"
+               "warning" | "GCC" | "STDC" | "clang"
              (* Solaris-style pragmas:  *)
              | "ident" | "section" | "option" | "asm" | "use_section" | "weak"
              | "redefine_extname"


### PR DESCRIPTION
Treat `#pragma clang ....` like `#pragma gcc ...` and a lot of others and ignore it.