### PR TITLE
Minimal support for `__auto_type`

### DIFF
--- a/src/frontc/cabs.ml
+++ b/src/frontc/cabs.ml
@@ -88,6 +88,7 @@ type typeSpecifier = (* Merge all specifiers into one type *)
   | TtypeofE of expression                      (* GCC __typeof__ *)
   | TtypeofT of specifier * decl_type       (* GCC __typeof__ *)
   | Tdefault (** "default" in generic associations *)
+  | Tauto (** GCC __auto_type *)
 
 and storage =
     NO_STORAGE | AUTO | STATIC | EXTERN | REGISTER

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -5886,7 +5886,7 @@ and doDecl (isglobal: bool) : A.definition -> chunk = function
       let doOneDeclarator (acc: chunk) (name: init_name) =
         let (n,ndt,a,l),_ = name in
         if isglobal then begin
-          let spec_res = Option.get spec_res in
+          let spec_res = match spec_res with Some s -> s | _ -> failwith "Option.get" in
           let bt,_,_,attrs = spec_res in
           let vtype, nattr = doType AttrName bt (A.PARENTYPE(attrs, ndt, a)) in
           (match filterAttributes "alias" nattr with

--- a/src/frontc/clexer.mll
+++ b/src/frontc/clexer.mll
@@ -198,6 +198,7 @@ let init_lexicon _ =
       ("__restrict", fun loc -> RESTRICT loc);
       ("__restrict__", fun loc -> RESTRICT loc);
       ("restrict", fun loc -> RESTRICT loc);
+      ("__auto_type", fun loc -> AUTOTYPE loc);
 (*      ("__extension__", EXTENSION); *)
       (**** MS VC ***)
       ("__int32", fun loc -> INT loc);

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -255,6 +255,7 @@ let transformOffsetOf (speclist, dtype) member =
 %token<Cabs.cabsloc> FLOAT32 FLOAT64 /* FloatN */
 %token<Cabs.cabsloc> FLOAT32X FLOAT64X /* FloatNx */
 %token<Cabs.cabsloc> GENERIC NORETURN /* C11 */
+%token<Cabs.cabsloc> AUTOTYPE /* GCC */
 %token<Cabs.cabsloc> ENUM STRUCT TYPEDEF UNION
 %token<Cabs.cabsloc> SIGNED UNSIGNED LONG SHORT
 %token<Cabs.cabsloc> VOLATILE EXTERN STATIC CONST ATOMIC RESTRICT AUTO REGISTER
@@ -1006,6 +1007,7 @@ type_spec:   /* ISO 6.7.2 */
 |   FLOAT32X        { Tfloat32x, $1 }
 |   FLOAT64X        { Tfloat64x, $1 }
 |   DOUBLE          { Tdouble, $1 }
+|   AUTOTYPE        { Tauto, $1 }
 /* |   COMPLEX FLOAT   { Tfloat, $2 } */
 /* |   COMPLEX FLOAT128{ Tfloat128, $2 } */
 /* |   COMPLEX DOUBLE  { Tdouble, $2 } */

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -1046,7 +1046,7 @@ type_spec:   /* ISO 6.7.2 */
 |   ENUM   just_attributes                LBRACE enum_list maybecomma RBRACE
                                                    { Tenum   ("", Some $4, $2), $1 }
 |   NAMED_TYPE      { Tnamed (fst $1), snd $1 }
-|   TYPEOF LPAREN expression RPAREN     { TtypeofE (fst $3), $1 }
+|   TYPEOF LPAREN comma_expression RPAREN     { TtypeofE (smooth_expression (fst $3)), $1 }
 |   TYPEOF LPAREN type_name RPAREN      { let s, d = $3 in
                                           TtypeofT (s, d), $1 }
 ;

--- a/src/frontc/cprint.ml
+++ b/src/frontc/cprint.ml
@@ -194,6 +194,7 @@ and print_type_spec = function
   | TtypeofE e -> printl ["__typeof__";"("]; print_expression e; print ") "
   | TtypeofT (s,d) -> printl ["__typeof__";"("]; print_onlytype (s, d); print ") "
   | Tdefault -> print "default " (* TODO: is this right? *)
+  | Tauto -> print "__auto_type"
 
 
 (* print "struct foo", but with specified keyword and a list of

--- a/test/small1/c11-atomic-store.c
+++ b/test/small1/c11-atomic-store.c
@@ -15,6 +15,18 @@ int main() {
     });
 
 
+    // Extended version from GCC
+    __extension__ ({ __auto_type __atomic_store_ptr = (
+
+    ptr
+    ); __typeof__ ((void)0, *__atomic_store_ptr) __atomic_store_tmp = (
+
+    17
+
+    ); __atomic_store (__atomic_store_ptr, &__atomic_store_tmp, (5)); })
+                        ;
+
+
     atomic_store(ptr,17);
     atomic_store_explicit(ptr,17,memory_order_relaxed);
     SUCCESS;

--- a/test/small1/c11-atomic-store.c
+++ b/test/small1/c11-atomic-store.c
@@ -1,0 +1,15 @@
+#include "testharness.h"
+#include <stdnoreturn.h>
+#include <stdatomic.h>
+
+typedef _Atomic _Bool atomic_bool;
+
+
+int main() {
+    atomic_int atomic;
+    int* ptr = &atomic;
+
+    atomic_store(ptr,17);
+    atomic_store_explicit(ptr,17,memory_order_consume);
+    SUCCESS;
+}

--- a/test/small1/c11-atomic-store.c
+++ b/test/small1/c11-atomic-store.c
@@ -6,10 +6,16 @@ typedef _Atomic _Bool atomic_bool;
 
 
 int main() {
-    atomic_int atomic;
-    int* ptr = &atomic;
+    atomic_int ato;
+    _Atomic int* ptr = &ato;
+
+    __extension__ ({
+        __auto_type blub = ato;
+        ato = 8;
+    });
+
 
     atomic_store(ptr,17);
-    atomic_store_explicit(ptr,17,memory_order_consume);
+    atomic_store_explicit(ptr,17,memory_order_relaxed);
     SUCCESS;
 }

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -698,6 +698,7 @@ addTest("testrunc11/c11-caserange");
 addTest("testrunc11/c11-extendedFloat");
 addTest("testrunc11/c11-noreturn");
 addTest("testrunc11/c11-atomic");
+addTest("testrunc11/c11-atomic-store");
 addTest("testrunc11/c11-static-assert");
 addTest("testrunc11/c11-align-of");
 addTest("testrunc11/gcc-c11-generic-1");


### PR DESCRIPTION
`GCC` makes use of the `__auto_type` feature in code that some C11 atomic accesses get turned into by the preprocessor.

Also, on OS X, in these cases, `comma_expressions` may appear inside of `__typeof__` without an additional pair of parentheses, so this PR also adds support for that.