### PR TITLE
Proposal: Do not attempt to merge `inline` functions by default

### DIFF
--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -67,9 +67,9 @@ let usePathCompression = false
  * merger an order of magnitude !!! *)
 let merge_inlines = ref false
 
-let mergeInlinesRepeat = !merge_inlines && true
+let mergeInlinesRepeat () = !merge_inlines && true
 
-let mergeInlinesWithAlphaConvert = !merge_inlines && true
+let mergeInlinesWithAlphaConvert () = !merge_inlines && true
 
 (* when true, merge duplicate definitions of externally-visible functions;
  * this uses a mechanism which is faster than the one for inline functions,
@@ -1481,7 +1481,7 @@ let oneFilePass2 (f: file) =
               in
               (* Remember the original type *)
               let origType = fdec'.svar.vtype in
-              if mergeInlinesWithAlphaConvert then begin
+              if mergeInlinesWithAlphaConvert () then begin
                 (* Rename the formals *)
                 List.iter renameOne fdec'.sformals;
                 (* Reflect in the type *)
@@ -1493,7 +1493,7 @@ let oneFilePass2 (f: file) =
               let res = d_global () g' in
               lineDirectiveStyle := oldprintln;
               fdec'.svar.vname <- newname;
-              if mergeInlinesWithAlphaConvert then begin
+              if mergeInlinesWithAlphaConvert () then begin
                 (* Do the locals in reverse order *)
                 List.iter undoRenameOne (List.rev fdec'.slocals);
                 (* Do the formals in reverse order *)
@@ -1526,7 +1526,7 @@ let oneFilePass2 (f: file) =
                * We should reuse this, but watch for the case when the inline
                * was already used. *)
               if H.mem varUsedAlready fdec'.svar.vname then begin
-                if mergeInlinesRepeat then begin
+                if mergeInlinesRepeat () then begin
                   repeatPass2 := true
                 end else begin
                   ignore (warn "Inline function %s because it is used before it is defined" fdec'.svar.vname);
@@ -1708,7 +1708,7 @@ let oneFilePass2 (f: file) =
   (* See if we must re-visit the globals in this file because an inline that
    * is being removed was used before we saw the definition and we decided to
    * remove it *)
-  if mergeInlinesRepeat && !repeatPass2 then begin
+  if mergeInlinesRepeat () && !repeatPass2 then begin
     if debugMerge || !E.verboseFlag then
       ignore (E.log "Repeat final merging phase (%d): %s\n"
                 !currentFidx f.fileName);

--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -65,7 +65,7 @@ let usePathCompression = false
 (* Try to merge definitions of inline functions. They can appear in multiple
  * files and we would like them all to be the same. This can slow down the
  * merger an order of magnitude !!! *)
-let mergeInlines = true
+let mergeInlines = false
 
 let mergeInlinesRepeat = mergeInlines && true
 
@@ -296,7 +296,7 @@ let tEq: (int * string, typeinfo node) H.t = H.create 111 (* Type names*)
 let iEq: (int * string, varinfo node) H.t = H.create 111 (* Inlines *)
 
 (* Sometimes we want to merge synonyms. We keep some tables indexed by names.
- * Each name is mapped to multiple exntries *)
+ * Each name is mapped to multiple entries *)
 let vSyn: (string, varinfo node) H.t = H.create 111 (* Not actually used *)
 let iSyn: (string, varinfo node) H.t = H.create 111 (* Inlines *)
 let sSyn: (string, compinfo node) H.t = H.create 111

--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -65,11 +65,11 @@ let usePathCompression = false
 (* Try to merge definitions of inline functions. They can appear in multiple
  * files and we would like them all to be the same. This can slow down the
  * merger an order of magnitude !!! *)
-let mergeInlines = false
+let merge_inlines = ref false
 
-let mergeInlinesRepeat = mergeInlines && true
+let mergeInlinesRepeat = !merge_inlines && true
 
-let mergeInlinesWithAlphaConvert = mergeInlines && true
+let mergeInlinesWithAlphaConvert = !merge_inlines && true
 
 (* when true, merge duplicate definitions of externally-visible functions;
  * this uses a mechanism which is faster than the one for inline functions,
@@ -540,7 +540,7 @@ let rec combineTypes (what: combineWhat)
           oldfidx oldrt fidx rt
       in
       if oldva != va then
-        raise (Failure "(diferent vararg specifiers)");
+        raise (Failure "(different vararg specifiers)");
       (* If one does not have arguments, believe the one with the
       * arguments *)
       let newargs =
@@ -879,7 +879,7 @@ let oneFilePass1 (f:file) : unit =
           if fdec.svar.vstorage <> Static then begin
             matchVarinfo fdec.svar (l, !currentDeclIdx)
           end else begin
-            if fdec.svar.vinline && mergeInlines then
+            if fdec.svar.vinline && !merge_inlines then
               (* Just create the nodes for inline functions *)
               ignore (getNode iEq iSyn !currentFidx
                         fdec.svar.vname fdec.svar (Some (l, !currentDeclIdx)))
@@ -1455,7 +1455,7 @@ let oneFilePass2 (f: file) =
             setFormals fdec fdec.sformals
           end;
           (* See if we can remove this inline function *)
-          if fdec'.svar.vinline && mergeInlines then begin
+          if fdec'.svar.vinline && !merge_inlines then begin
             let printout =
               (* Temporarily turn of printing of lines *)
               let oldprintln = !lineDirectiveStyle in
@@ -1754,7 +1754,7 @@ let merge (files: file list) (newname: string) : file =
     doMergeSynonyms sSyn sEq matchCompInfo;
     doMergeSynonyms eSyn eEq matchEnumInfo;
     doMergeSynonyms tSyn tEq matchTypeInfo;
-    if mergeInlines then begin
+    if !merge_inlines then begin
       (* Copy all the nodes from the iEq to vEq as well. This is needed
        * because vEq will be used for variable renaming *)
       H.iter (fun k n -> H.add vEq k n) iEq;
@@ -1768,7 +1768,7 @@ let merge (files: file list) (newname: string) : file =
     dumpGraph "struct and union" sEq;
     dumpGraph "enum" eEq;
     dumpGraph "variable" vEq;
-    if mergeInlines then dumpGraph "inline" iEq;
+    if !merge_inlines then dumpGraph "inline" iEq;
   end;
   (* Make the second pass over the files. This is when we start rewriting the
    * file *)

--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -1457,7 +1457,7 @@ let oneFilePass2 (f: file) =
           (* See if we can remove this inline function *)
           if fdec'.svar.vinline && !merge_inlines then begin
             let printout =
-              (* Temporarily turn of printing of lines *)
+              (* Temporarily turn off printing of lines *)
               let oldprintln = !lineDirectiveStyle in
               lineDirectiveStyle := None;
               (* Temporarily set the name to all functions in the same way *)

--- a/src/mergecil.mli
+++ b/src/mergecil.mli
@@ -1,11 +1,11 @@
 (*
  *
- * Copyright (c) 2001-2002, 
+ * Copyright (c) 2001-2002,
  *  George C. Necula    <necula@cs.berkeley.edu>
  *  Scott McPeak        <smcpeak@cs.berkeley.edu>
  *  Wes Weimer          <weimer@cs.berkeley.edu>
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
@@ -37,6 +37,11 @@
 
 (** Set this to true to ignore the merge conflicts *)
 val ignore_merge_conflicts: bool ref
+
+(** Try to merge definitions of inline functions. They can appear in multiple
+ * files and we would like them all to be the same. This can slow down the
+ * merger an order of magnitude !!! *)
+val merge_inlines: bool ref
 
 (** Merge a number of CIL files *)
 val merge: Cil.file list -> string -> Cil.file


### PR DESCRIPTION
Currently, CIL attempts to merge `inline` functions, such that there is only one definition of them, instead of renaming and keeping all appearing definitions.
With projects such as https://github.com/goblint/bench/issues/16, we run into issues because we have `static inline` functions for which CIL merges the definitions but not the declarations, leading to warnings where we have multiple globals that have different `varinfo`s that share the same name. 
This (potentially) confuses the incremental analysis which assumes there is at-most one varinfo per global name in Goblint.
Also, having >100 of these warnings is also not too nice.

**Advantages:**
- Gets rid of these warnings
- Makes things easier for Goblint on the incremental side
- Potentially leads to a speed up of an order of magnitude according to comments 
- Seems like the morally right thing to do for `static inline` functions: They are different if they come from different translation units, even if they happen to share the same code
- ...

**Disadvantages:**
- Potentially increases the size of the merged output (potentially leading to more code to analyze)
- ...

