### PR TITLE
Support for comma-separated list of declarations with attributes in non-leading position

### DIFF
--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -957,6 +957,8 @@ static_assert_declaration:
 init_declarator_list:                       /* ISO 6.7 */
     init_declarator                              { [$1] }
 |   init_declarator COMMA init_declarator_attr_list   { $1 :: $3 }
+  /* Here we disallow attributes for the declarator. Attributes appearing there are parsed as if they belong to the type.  */
+  /* See also https://gcc.gnu.org/onlinedocs/gcc/Attribute-Syntax.html */
 ;
 
 init_declarator_attr_list:

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -956,7 +956,20 @@ static_assert_declaration:
 ;
 init_declarator_list:                       /* ISO 6.7 */
     init_declarator                              { [$1] }
-|   init_declarator COMMA init_declarator_list   { $1 :: $3 }
+|   init_declarator COMMA init_declarator_attr_list   { $1 :: $3 }
+;
+
+init_declarator_attr_list:
+  init_declarator_attr { [ $1 ] }
+| init_declarator_attr COMMA init_declarator_attr_list { $1 :: $3 }
+;
+
+init_declarator_attr:
+  attribute_nocv_list init_declarator {
+    let ((name, decl, attrs, loc), init) = $2 in
+    ((name, PARENTYPE ($1,decl,[]), attrs, loc), init)
+  }
+;
 
 ;
 init_declarator:                             /* ISO 6.7 */

--- a/test/small1/attr-in-decllist.c
+++ b/test/small1/attr-in-decllist.c
@@ -1,6 +1,7 @@
 int __attribute__((unused))version,j;
 int i, ret, __attribute__((unused))version2, nb_curves;
 int i2, ret2, __attribute__((unused))(version3), nb_curves2;
+int i3, ret3, (__attribute__((unused))version4), nb_curves3;
 
 int main(void) {
     return 0;

--- a/test/small1/attr-in-decllist.c
+++ b/test/small1/attr-in-decllist.c
@@ -1,0 +1,7 @@
+int __attribute__((unused))version,j;
+int i, ret, __attribute__((unused))version2, nb_curves;
+int i2, ret2, __attribute__((unused))(version3), nb_curves2;
+
+int main(void) {
+    return 0;
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -208,6 +208,8 @@ addTest("testrun/percentm");
 addTest("testrun/percent400");
 addTest("testrun/caserange _GNUCC=1");
 
+addTest("testrun/attr-in-decllist");
+
 addTest("test/attr2 _GNUCC=1");
 addTest("test/attr3 _GNUCC=1");
 addTest("testrun/attr4 _GNUCC=1");


### PR DESCRIPTION
Fixes #76. In later declarations attributes may appear without leading parenthesis. A naive fix would introduce tons of conflicts once again.

The fix here is imported from the (absorbed) CIL fork used by Frama-C (allowed by the license of the components that used to be part of `frontc`/CIL) at https://git.frama-c.com/pub/frama-c/-/blob/master/src/kernel_internals/parsing/cparser.mly.