### PR TITLE
Replace calls to `__builtin_nanX` with expression leading to NaN

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -4248,25 +4248,17 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
          * functions alone*)
         let isSpecialBuiltin =
           match f'' with
-            Lval (Var fv, NoOffset) ->
-              fv.vname = "__builtin_stdarg_start" ||
-              fv.vname = "__builtin_va_arg" ||
-              fv.vname = "__builtin_va_start" ||
-              fv.vname = "__builtin_expect" ||
-              fv.vname = "__builtin_next_arg" ||
-              fv.vname = "__builtin_tgmath"
-            | _ -> false
+          | Lval (Var {vname= ("__builtin_stdarg_start" | "__builtin_va_arg" | "__builtin_va_start" | "__builtin_expect" | "__builtin_next_arg" | "__builtin_tgmath"); _}, NoOffset) -> true
+          | _ -> false
         in
         let isBuiltinChooseExprOrTgmath =
           match f'' with
-            Lval (Var fv, NoOffset) ->
-              fv.vname = "__builtin_choose_expr" || fv.vname = "__builtin_tgmath"
-            | _ -> false
+          | Lval (Var {vname= "__builtin_choose_expr" | "__builtin_tgmath"; _ }, NoOffset) -> true
+          | _ -> false
         in
         let isBuiltinNan =
           match f'' with
-          | Lval (Var fv, NoOffset) -> fv.vname = "__builtin_nan" || fv.vname = "__builtin_nanf" ||
-            fv.vname = "__builtin_nanl" || fv.vname = "__builtin_nans" || fv.vname = "__builtin_nansf" || fv.vname = "__builtin_nansl"
+          | Lval (Var {vname= ("__builtin_nan" | "__builtin_nanf" | "__builtin_nanl" | "__builtin_nans" | "__builtin_nansf" | "__builtin_nansl"); _}, NoOffset) -> true
           | _ -> false
         in
         if isBuiltinNan && asconst then

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -4269,7 +4269,7 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
             fv.vname = "__builtin_nanl" || fv.vname = "__builtin_nans" || fv.vname = "__builtin_nansf" || fv.vname = "__builtin_nansl"
           | _ -> false
         in
-        if isBuiltinNan then
+        if isBuiltinNan && asconst then
           (* Replace call to builtin nan with computation yielding NaN *)
           let onef = Const(CReal(1.0,FDouble,None)) in
           let zerodivzero = mkCast (BinOp(Div,onef,onef,doubleType)) resType in

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -4271,7 +4271,7 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
         in
         if isBuiltinNan && asconst then
           (* Replace call to builtin nan with computation yielding NaN *)
-          let onef = Const(CReal(1.0,FDouble,None)) in
+          let onef = Const(CReal(0.0,FDouble,None)) in
           let zerodivzero = mkCast (BinOp(Div,onef,onef,doubleType)) resType in
           (empty,zerodivzero,resType)
         else (

--- a/test/small1/nan-global.c
+++ b/test/small1/nan-global.c
@@ -1,0 +1,7 @@
+#include<math.h>
+double e = __builtin_nanf("")+1.0;
+double d = NAN;
+
+int main(void) {
+	return 0;
+}

--- a/test/small1/nan-global.c
+++ b/test/small1/nan-global.c
@@ -1,7 +1,11 @@
 #include<math.h>
+#include "testharness.h"
 double e = __builtin_nanf("")+1.0;
 double d = NAN;
 
 int main(void) {
-	return 0;
+	if (e == e) { E(1); }
+	if (d == d) { E(2); }
+
+	SUCCESS;
 }

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -370,6 +370,7 @@ addTest("test/voidstar");
 addTest("testrun/memcpy1");
 addTest("testrun/land_expr");
 
+addTest("testrun/nan-global");
 
 addTest("test/noreturn ");
 


### PR DESCRIPTION
Fixes https://github.com/goblint/cil/issues/78, by replacing calls to `__builtin_nanX` which may not appear in locations where we expect a constant value, e.g. global initializers, with the expression `0./0.` which will yield NaN (on any sensible machine).

Needed for https://github.com/goblint/bench/issues/14