### PR TITLE
Rename functions with `gnu_inline` attribute when inline merging is off

### DIFF
--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -1341,7 +1341,7 @@ let oneFilePass2 (f: file) =
         vi (* Already done *)
       else begin
         (* Maybe it is static. Rename it then *)
-        if vi.vstorage = Static then begin
+        if vi.vstorage = Static || (not !merge_inlines && hasAttribute "gnu_inline" (typeAttrs vi.vtype)) then begin
           let newName, _ = A.newAlphaName ~alphaTable:vtAlpha ~undolist:None ~lookupname:vi.vname ~data:!currentLoc in
           (* Remember the original name *)
           H.add originalVarNames newName vi.vname;

--- a/test/Makefile
+++ b/test/Makefile
@@ -288,6 +288,13 @@ combine%: $(SMALL1)/combine%_1.c
 	            $(EXEOUT)combine$*.exe
 	cd $(SMALL1); ./combine$*.exe
 
+combinegnuinline:
+	cd $(SMALL1); \
+          $(CILLY) --merge $(CFLAGS)  -std=gnu90 -fcommon \
+                    combinegnuinline_1.c combinegnuinline_2.c \
+	            $(EXEOUT)combinegnuinline.exe
+	cd $(SMALL1); ./combinegnuinline.exe
+
 arcombine: mustbegcc
 	cd $(SMALL1); $(CILLY) -c array1.c array2.c
 	cd $(SMALL1); $(CILHOME)/bin/cilly \

--- a/test/small1/combinegnuinline_1.c
+++ b/test/small1/combinegnuinline_1.c
@@ -1,0 +1,8 @@
+// https://github.com/goblint/cil/pull/85
+#include <assert.h>
+#include "combinegnuinline_header.h"
+int main() {
+    int x = goo();
+    assert(x == 2);
+    return 0;
+}

--- a/test/small1/combinegnuinline_2.c
+++ b/test/small1/combinegnuinline_2.c
@@ -1,0 +1,4 @@
+#include "combinegnuinline_header.h"
+int goo() {
+    return 2;
+}

--- a/test/small1/combinegnuinline_header.h
+++ b/test/small1/combinegnuinline_header.h
@@ -1,0 +1,2 @@
+extern inline __attribute__((__gnu_inline__)) int foo()
+{ return 5; }

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -610,6 +610,7 @@ addTest("combine_syserr");
 addTest("combine_syserr MERGEINLINES=1");
 addTest("combine_copyptrs WARNINGS_ARE_ERRORS=1");
 addTest("combine_copyptrs WARNINGS_ARE_ERRORS=1 MERGEINLINES=1");
+addTest("combinegnuinline");
 
 addTest("testrun/constfold EXTRAARGS=\"--domakeCFG --dopartial\"");
 addBadComment("testrun/constfold", "Bug. Wrong constant folding.  #2276515 on sourceforge.");


### PR DESCRIPTION
With gcc 4.3 the semantic of extern inline was changed to conform with the ISO C99 standard (https://gcc.gnu.org/gcc-4.3/porting_to.html). Functions that should still have the GNU extern inline behavior have the attribute `__attribute__((__gnu_inline__))`. A function with this attribute in a header that is included in multiple different translation units leads to multiple function variables with the same name. This violates the check that was added with https://github.com/goblint/analyzer/commit/39d72880888da8cc8aa65b914b90bbc174e7a3b7. By renaming function variables, that have this `gnu_inline` attribute, whenever inline functions are not merged, fixes this. Below is an example where the problem can be observed:

`./goblint --enable incremental.save --disable incremental.load file1.c file2.c`
`./goblint --disable incremental.save --enable incremental.load file1.c file2.c`
or alternatively using `--set pre.cppflags[+] -fgnu89-inline` instead of the `__attribute__((__gnu_inline__))` in the function definition
```
//file.h
extern inline __attribute__((__gnu_inline__)) int foo()
{ return 5; }
```
```
//file1.c
#include "file.h"
int goo() {
    return 2;
}
```
```
//file2.c
#include <assert.h>
#include "file.h"
int main() {
    int x = goo();
    assert(x == 2);
    return 0;
}
```