### PR TITLE
Merging: Treat inlines as if they were static when mergeInlines is off

### DIFF
--- a/src/check.ml
+++ b/src/check.ml
@@ -93,6 +93,8 @@ let varIdsEnv: (int, varinfo) H.t = H.create 117
    * identifiers *)
 let allVarIds: (int, varinfo) H.t = H.create 117
 
+let fundecForVarIds: (int,unit) H.t = H.create 117
+
  (* Also keep a list of environments. We place an empty string in the list to
   * mark the start of a local environment (i.e. a function) *)
 let varNamesList : (string * int) list ref = ref []
@@ -961,6 +963,9 @@ let rec checkGlobal = function
       (* Check if this is the first occurrence *)
       let vi = fd.svar in
       let fname = vi.vname in
+      if H.mem fundecForVarIds vi.vid then
+        ignore (warn "There already is a different fundec for vid %d is already defined (%s)" vi.vid vi.vname);
+
       E.withContext (fun _ -> dprintf "GFun(%s)" fname)
         (fun _ ->
           checkGlobal (GVarDecl (vi, l));
@@ -1072,6 +1077,7 @@ let checkFile flags fl =
   H.clear varNamesEnv;
   H.clear varIdsEnv;
   H.clear allVarIds;
+  H.clear fundecForVarIds;
   H.clear compNames;
   H.clear compUsed;
   H.clear enumUsed;

--- a/src/check.ml
+++ b/src/check.ml
@@ -964,7 +964,7 @@ let rec checkGlobal = function
       let vi = fd.svar in
       let fname = vi.vname in
       if H.mem fundecForVarIds vi.vid then
-        ignore (warn "There already is a different fundec for vid %d is already defined (%s)" vi.vid vi.vname);
+        ignore (warn "There already is a different fundec for vid %d (%s)" vi.vid vi.vname);
 
       E.withContext (fun _ -> dprintf "GFun(%s)" fname)
         (fun _ ->

--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -1453,7 +1453,7 @@
                if debugInlines then ignore (E.log " Not found\n");
                H.add inlineBodies printout inode;
                mergePushGlobal g')
-           else if mergeGlobals && (not fdec'.svar.vinline) && fdec'.svar.vstorage <> Static then (
+           else if mergeGlobals && not (fdec'.svar.vstorage = Static || fdec'.svar.vinline) then ( (* !merge_inlines is false here anyway *)
              (* either the function is not inline, or we're not attempting to  merge inlines *)
              (* sm: this is a non-inline, non-static function. I want to consider dropping it if a same-named function has already been put into the merged file *)
              let sum = functionChecksum fdec' in

--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -1378,24 +1378,24 @@
            (* We must keep this definition even if we reuse this varinfo, because maybe the previous one was a declaration *)
            H.add emittedVarDecls vi.vname true;
            if mergeGlobals then
-            match H.find_opt emittedVarDefn vi'.vname with
-            | None ->
-              (* no previous definition *)
-              H.add emittedVarDefn vi'.vname (vi', init.init, l);
-              mergePushGlobals (visitCilGlobal renameVisitor (GVar (vi', init, l)))
-            | Some (prevVar, prevInitOpt, prevLoc) ->
-              if equalInitOpts prevInitOpt init.init || init.init = None then
-                trace "mergeGlob" (P.dprintf "dropping global var %s at %a in favor of the one at %a\n" vi'.vname d_loc l d_loc prevLoc)
-                (* do not emit *)
-              else if prevInitOpt = None then
-                (* We have an initializer, but the previous one didn't. We should really convert the previous global from GVar to GVarDecl, but that's not convenient to do here. *)
-                mergePushGlobals (visitCilGlobal renameVisitor (GVar (vi', init, l)))
-              else
-                (* Both GVars have initializers. *)
-                E.s (error "global var %s at %a has different initializer than %a" vi'.vname d_loc l d_loc prevLoc)
+             match H.find_opt emittedVarDefn vi'.vname with
+             | None ->
+               (* no previous definition *)
+               H.add emittedVarDefn vi'.vname (vi', init.init, l);
+               mergePushGlobals (visitCilGlobal renameVisitor (GVar (vi', init, l)))
+             | Some (prevVar, prevInitOpt, prevLoc) ->
+               if equalInitOpts prevInitOpt init.init || init.init = None then
+                 trace "mergeGlob" (P.dprintf "dropping global var %s at %a in favor of the one at %a\n" vi'.vname d_loc l d_loc prevLoc)
+                 (* do not emit *)
+               else if prevInitOpt = None then
+                 (* We have an initializer, but the previous one didn't. We should really convert the previous global from GVar to GVarDecl, but that's not convenient to do here. *)
+                 mergePushGlobals (visitCilGlobal renameVisitor (GVar (vi', init, l)))
+               else
+                 (* Both GVars have initializers. *)
+                 E.s (error "global var %s at %a has different initializer than %a" vi'.vname d_loc l d_loc prevLoc)
            else
-            (* Not merging globals, nothing to be done*)
-            mergePushGlobals (visitCilGlobal renameVisitor (GVar (vi', init, l)))
+             (* Not merging globals, nothing to be done*)
+             mergePushGlobals (visitCilGlobal renameVisitor (GVar (vi', init, l)))
        | GFun (fdec, l) as g ->
            currentLoc := l;
            incr currentDeclIdx;

--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -1344,9 +1344,9 @@
      (* Process a varinfo. Reuse an old one, or rename it if necessary *)
      let processVarinfo (vi : varinfo) (vloc : location) : varinfo =
        if vi.vreferenced then vi (* Already done *)
-       else if vi.vstorage = Static || (not !merge_inlines) && hasAttribute "gnu_inline" (typeAttrs vi.vtype) then
+       else if vi.vstorage = Static || (vi.vinline && not (!merge_inlines)) then
         (
-         (* Maybe it is static. Rename it then *)
+         (* Maybe it is static or inline and we are not merging inlines. Rename it then *)
          let newName, _ = A.newAlphaName ~alphaTable:vtAlpha ~undolist:None ~lookupname:vi.vname ~data:!currentLoc in
          (* Remember the original name *)
          H.add originalVarNames newName vi.vname;

--- a/src/mergecil.ml
+++ b/src/mergecil.ml
@@ -312,14 +312,10 @@
   * names must be different from variable names!! We one alpha table both for
   * variables and types. *)
  let vtAlpha : (string, location A.alphaTableData ref) H.t = H.create 57
- (* Variables and
-                                            * types *)
+ (* Variables and types *)
 
  let sAlpha : (string, location A.alphaTableData ref) H.t = H.create 57
- (* Structures and
-                                            * unions have
-                                            * the same name
-                                            * space *)
+ (* Structures and unions have the same name space *)
 
  let eAlpha : (string, location A.alphaTableData ref) H.t = H.create 57
  (* Enumerations *)
@@ -1159,11 +1155,8 @@
      | ComputedGoto _ -> 131
      | Break _ -> 23
      | Continue _ -> 29
-     | If (_, b1, b2, _, _) ->
-         31 + (37 * stmtListSum b1.bstmts) + (41 * stmtListSum b2.bstmts)
-     | Switch (_, b, _, _, _) ->
-         43 + (47 * stmtListSum b.bstmts)
-         (* don't look at stmt list b/c is not part of tree *)
+     | If (_, b1, b2, _, _) -> 31 + (37 * stmtListSum b1.bstmts) + (41 * stmtListSum b2.bstmts)
+     | Switch (_, b, _, _, _) -> 43 + (47 * stmtListSum b.bstmts) (* don't look at stmt list b/c is not part of tree *)
      | Loop (b, _, _, _, _) -> 49 + (53 * stmtListSum b.bstmts)
      | Block b -> 59 + (61 * stmtListSum b.bstmts)
    in
@@ -1205,8 +1198,7 @@
        (* types need to be identically equal *)
        let rec equalLists xoil yoil : bool =
          match (xoil, yoil) with
-         | (xo, xi) :: xrest, (yo, yi) :: yrest ->
-             equalOffsets xo yo && equalInits xi yi && equalLists xrest yrest
+         | (xo, xi) :: xrest, (yo, yi) :: yrest -> equalOffsets xo yo && equalInits xi yi && equalLists xrest yrest
          | [], [] -> true
          | _, _ -> false
        in
@@ -1231,9 +1223,7 @@
        (* safe to use '=' on literals *)
        (* CIL changes (unsigned)0 into 0U during printing.. *)
        match (xc, yc) with
-       | CInt (a, _, _), CInt (b, _, _)
-         when Cilint.is_zero_cilint a && Cilint.is_zero_cilint b ->
-           true (* ok if they're both 0 *)
+       | CInt (a, _, _), CInt (b, _, _) -> Cilint.is_zero_cilint a && Cilint.is_zero_cilint b (* ok if they're both 0 *)
        | _, _ -> false)
    | Lval xl, Lval yl -> equalLvals xl yl
    | SizeOf xt, SizeOf yt ->


### PR DESCRIPTION
This should hopefully fix all issues with merging of inlines. The logic now is as follows:

If `merge_inlines` is off (default), inline functions are handled as if they were static, meaning they will always be renamed. This should fix any unintended instances of multiple `fundec`s for one given `varinfo`.