### PR TITLE
Expose standalone expression parsing via Frontc

### DIFF
--- a/src/frontc/cabs2cil.mli
+++ b/src/frontc/cabs2cil.mli
@@ -109,3 +109,5 @@ val environment : (string, envdata * Cil.location) Hashtbl.t
 val genvironment : (string, envdata * Cil.location) Hashtbl.t
 
 val convStandaloneExp: genv:(string, envdata * Cil.location) Hashtbl.t -> env:(string, envdata * Cil.location) Hashtbl.t -> Cabs.expression -> Cil.exp option
+
+val currentFunctionFDEC: Cil.fundec ref

--- a/src/frontc/cabs2cil.mli
+++ b/src/frontc/cabs2cil.mli
@@ -106,3 +106,6 @@ type envdata =
 (** A hashtable containing a mapping of variables, enums, types and labels to varinfo, typ, etc. *)
 (*  It enables a lookup of the original variable names before the alpha conversion by cabs2cil *)
 val environment : (string, envdata * Cil.location) Hashtbl.t
+val genvironment : (string, envdata * Cil.location) Hashtbl.t
+
+val convStandaloneExp: genv:(string, envdata * Cil.location) Hashtbl.t -> env:(string, envdata * Cil.location) Hashtbl.t -> Cabs.expression -> Cil.exp option

--- a/src/frontc/clexer.mli
+++ b/src/frontc/clexer.mli
@@ -43,6 +43,7 @@
 
 
 val init: filename:string -> Lexing.lexbuf
+val initFromString: string -> Lexing.lexbuf
 val finish: unit -> unit
 
 (* This is the main parser function *)

--- a/src/frontc/clexer.mll
+++ b/src/frontc/clexer.mll
@@ -283,6 +283,18 @@ let init ~(filename: string) : Lexing.lexbuf =
   Lexerhack.add_identifier := add_identifier;
   E.startParsing filename
 
+let initFromString (s: string) : Lexing.lexbuf =
+  init_lexicon ();
+  (* Inititialize the pointer in Errormsg *)
+  Lexerhack.add_type := add_type;
+  (* add some built-in types which are handled as Tnamed in cabs2cil *)
+  add_type "__int128_t"; (* __int128 *)
+  add_type "__uint128_t"; (* unsigned __int128 *)
+  Lexerhack.push_context := push_context;
+  Lexerhack.pop_context := pop_context;
+  Lexerhack.add_identifier := add_identifier;
+  E.startParsingFromString s
+
 
 let finish () =
   E.finishParsing ()

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -346,7 +346,7 @@ let transformOffsetOf (speclist, dtype) member =
 %left   IDENT
 
 /* Non-terminals informations */
-%start interpret file
+%start interpret file expression
 %type <Cabs.definition list> file interpret globals
 
 %type <Cabs.definition> global
@@ -356,7 +356,7 @@ let transformOffsetOf (speclist, dtype) member =
 %type <Cabs.statement> statement
 %type <Cabs.constant * cabsloc> constant
 %type <int64 list Queue.t * Cabs.wchar_type * cabsloc> string_list
-%type <Cabs.expression * cabsloc> expression
+%type <Cabs.expression * Cabs.cabsloc> expression
 %type <Cabs.expression> opt_expression
 %type <Cabs.init_expression> init_expression
 %type <Cabs.expression list * cabsloc> comma_expression

--- a/src/frontc/frontc.mli
+++ b/src/frontc/frontc.mli
@@ -50,3 +50,5 @@ val args: (string * Arg.spec * string) list
 val parse: string -> (unit -> Cil.file)
 
 val parse_with_cabs: string -> (unit -> Cabs.file * Cil.file)
+
+val parse_standalone_exp: string -> Cabs.expression


### PR DESCRIPTION
This is currently on top of #96, but could be rebased if necessary.

Since `Formatcil` is not intended for parsing standalone expressions from user input and is very fragile (#94, #95), then this is an attempt to provide a proper alternative. It exposes Frontc and Cabs2cil functions for parsing just an expression from a given string. This allows expressions to be parsed using the normal parsing pipeline with all the usual behavior (correct typing, implicit casts, etc).

This is a more reliable alternative to be used in https://github.com/goblint/analyzer/pull/745.

This might still be buggy, because `doPureExp`, which is at the center of this, uses at least 30 global variables (I might have missed some). Here I just require `env` and `genv` to be given such that the expression can be converted to CIL in the correct function's context (with all the variables referring to a particular function's locals). As to rest of the globals, there's no way to reconstruct their content at a particular function as they were when the entire file was parsed, so this might still break in surprising ways, but it should already be better than `Formatcil`.