### PR TITLE
Add option `removeBranchingOnConstants`

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -97,6 +97,9 @@ let envMachine : M.mach option ref = ref None
 let lowerConstants: bool ref = ref true
     (** Do lower constants (default true) *)
 
+let removeBranchingOnConstants: bool ref = ref true
+    (** Remove branches of the form if(const) ... else ... (default true) *)
+
 let insertImplicitCasts: bool ref = ref true
     (** Do insert implicit casts (default true) *)
 

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -2697,10 +2697,10 @@ and constFoldBinOp (machdep: bool) bop e1 e2 tres =
       | Lt, Some i1, Some i2 -> if compare_cilint i1 i2 < 0 then one else zero
       | Gt, Some i1, Some i2 -> if compare_cilint i1 i2 > 0 then one else zero
 
-      | LAnd, Some i1, _ -> if is_zero_cilint i1 then collapse0 () else collapse e2'
-      | LAnd, _, Some i2 -> if is_zero_cilint i2 then collapse0 () else collapse e1'
-      | LOr, Some i1, _ -> if is_zero_cilint i1 then collapse e2' else one
-      | LOr, _, Some i2 -> if is_zero_cilint i2 then collapse e1' else one
+      | LAnd, Some i1, _  when !removeBranchingOnConstants -> if is_zero_cilint i1 then collapse0 () else collapse e2'
+      | LAnd, _, Some i2 when !removeBranchingOnConstants -> if is_zero_cilint i2 then collapse0 () else collapse e1'
+      | LOr, Some i1, _ when !removeBranchingOnConstants -> if is_zero_cilint i1 then collapse e2' else one
+      | LOr, _, Some i2 when !removeBranchingOnConstants -> if is_zero_cilint i2 then collapse e1' else one
 
       | _ -> BinOp(bop, e1', e2', tres)
     in

--- a/src/cil.mli
+++ b/src/cil.mli
@@ -1128,6 +1128,9 @@ and typsig =
 val lowerConstants: bool ref
     (** Do lower constants (default true) *)
 
+val removeBranchingOnConstants: bool ref
+    (** Remove branches of the form if(const) ... else ... (default true) *)
+
 val insertImplicitCasts: bool ref
     (** Do insert implicit casts (default true) *)
 

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -5167,8 +5167,8 @@ and compileCondExp (ce: condExpRes) (st: chunk) (sf: chunk) : chunk =
 
   | CEExp (se, e) -> begin
       match e with
-        Const(CInt(i,_,_)) when not (is_zero_cilint i) && canDrop sf -> se @@ st
-      | Const(CInt(z,_,_)) when is_zero_cilint z && canDrop st -> se @@ sf
+        Const(CInt(i,_,_)) when not (is_zero_cilint i) && canDrop sf && !Cil.removeBranchingOnConstants -> se @@ st
+      | Const(CInt(z,_,_)) when is_zero_cilint z && canDrop st && !Cil.removeBranchingOnConstants -> se @@ sf
       | _ -> se @@ ifChunk e !currentLoc !currentExpLoc st sf
   end
 


### PR DESCRIPTION
This option can be used to disable the removal of the non-taken branches for branching over constants.

Enables analyzers to report such code as dead to the users. (c.f. https://github.com/goblint/analyzer/issues/94)