### PR TITLE
Remove batteries dependency to support OCaml 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
           - 4.12.0
           - 4.13.1
           - 4.14.x
-          - ocaml-base-compiler.5.0.0~alpha0
+          - ocaml-base-compiler.5.0.0~alpha1
 
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,6 @@ jobs:
           - ubuntu-latest
           # - windows-latest
         ocaml-version:
-          # - 4.04.2
           - 4.05.0
           - 4.06.1
           - 4.07.1
@@ -26,6 +25,7 @@ jobs:
           - 4.12.0
           - 4.13.1
           - 4.14.x
+          - ocaml-base-compiler.5.0.0~alpha0
 
 
     runs-on: ${{ matrix.os }}

--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,6 @@ Changes:
     stdlib-shims
     (ppx_deriving_yojson (>= 3.2))
     yojson
-    (batteries (>= 3.2.0))
     conf-perl
     cppo
   )

--- a/goblint-cil.opam
+++ b/goblint-cil.opam
@@ -35,7 +35,6 @@ depends: [
   "stdlib-shims"
   "ppx_deriving_yojson" {>= "3.2"}
   "yojson"
-  "batteries" {>= "3.2.0"}
   "conf-perl"
   "cppo"
 ]

--- a/src/dune
+++ b/src/dune
@@ -4,7 +4,7 @@
   (public_name goblint-cil)
   (name cil)
   (wrapped false) ; this should be changed, but then module paths in goblint need to be prefixed
-  (libraries zarith findlib dynlink unix str stdlib-shims batteries.unthreaded) ; batteries shouldn't be needed, but tests fail on MacOS otherwise: https://github.com/goblint/cil/pull/89#issuecomment-1092610041
+  (libraries zarith findlib dynlink unix str stdlib-shims)
   (modules (:standard \ main machdepConfigure))
 )
 

--- a/src/ext/syntacticsearch/dune
+++ b/src/ext/syntacticsearch/dune
@@ -2,6 +2,6 @@
   (public_name goblint-cil.syntacticsearch)
   (name syntacticsearch)
   (wrapped false) ; this should be changed, but then module paths in goblint need to be prefixed
-  (libraries goblint-cil yojson ppx_deriving_yojson.runtime batteries.unthreaded)
+  (libraries goblint-cil yojson ppx_deriving_yojson.runtime)
   (preprocess (pps ppx_deriving_yojson))
 )

--- a/src/ext/syntacticsearch/funcDatatype.ml
+++ b/src/ext/syntacticsearch/funcDatatype.ml
@@ -2,7 +2,7 @@ open Cil
 
 (* Finds definition of a user-defined type *)
 let find_def name file =
-  BatList.filter_map
+  Util.list_filter_map
     (function
       | GType (info, loc) ->
           if String.compare name info.tname = 0 then Some ("", loc, name, -1)
@@ -18,7 +18,7 @@ let find_def name file =
 
 (* Finds all definition of user-defined types *)
 let find_def_all file =
-  BatList.filter_map
+  Util.list_filter_map
     (function
       | GType (info, loc) -> Some ("", loc, info.tname, -1)
       | GCompTag (info, loc) -> Some ("", loc, info.cname, -1)
@@ -27,7 +27,7 @@ let find_def_all file =
     file.globals
 
 let find_in_globals list name =
-  BatList.filter_map
+  Util.list_filter_map
     (function
       | GVar (info, _, _) ->
           if
@@ -40,7 +40,7 @@ let find_in_globals list name =
     list
 
 let find_in_varinfos list name =
-  BatList.filter_map
+  Util.list_filter_map
     (fun info ->
       if
         String.compare name
@@ -52,7 +52,7 @@ let find_in_varinfos list name =
 
 let find_fundec globals name =
   let gfun =
-    BatList.find_opt
+    List.find_opt
       (function
         | GFun (fundec, _) -> String.compare fundec.svar.vname name = 0
         | _ -> false)

--- a/src/ext/syntacticsearch/funcFunction.ml
+++ b/src/ext/syntacticsearch/funcFunction.ml
@@ -20,7 +20,7 @@ let map_gfun f = function GFun (dec, loc) -> f dec loc | _ -> None
 
 let find_all_with_origname n =
   let ns = Hashtbl.find_all environment n in
-  BatList.filter_map (function | (EnvVar v,_) -> Some v.vname | _ -> None) ns
+  Util.list_filter_map (function | (EnvVar v,_) -> Some v.vname | _ -> None) ns
 
 class fun_find_returns funname funid result : nopCilVisitor =
   object
@@ -58,7 +58,7 @@ let find_returns funname funid file =
 (* Finds all returns in all functions *)
 let find_returns_all file =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun fundec _ -> Some (find_returns "" fundec.svar.vid file)))
        file.globals
 
@@ -121,18 +121,18 @@ let find_def funname funid file =
       Some (fundec.svar.vname, loc, create_sig fundec file, fundec.svar.vid)
     else None
   in
-  BatList.filter_map (map_gfun fn) file.globals
+  Util.list_filter_map (map_gfun fn) file.globals
 
 (* Finds all definitions of all functions *)
 let find_def_all file =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun fundec _ -> Some (find_def "" fundec.svar.vid file)))
        file.globals
 
 let find_fundec funname funid list =
   let gfun =
-    BatList.find_opt
+    List.find_opt
       (fun x ->
         match x with
         | GFun (dec, _) -> is_equal_funname_funid dec.svar funname funid
@@ -170,7 +170,7 @@ let find_uses funname funid file =
 (* Find all calls of all functions in all functions *)
 let find_uses_all file =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun fundec _ -> Some (find_uses "" fundec.svar.vid file)))
        file.globals
 
@@ -210,7 +210,7 @@ let find_uses_in_fun funname funid funstrucname file =
 (* Finds all calls of all functions in a function *)
 let find_uses_in_fun_all funstrucname file =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun fundec _ ->
             Some (find_uses_in_fun "" fundec.svar.vid funstrucname file)))
        file.globals
@@ -272,7 +272,7 @@ let find_usesvar_in_fun funname funid funstrucname varname file =
 (* Finds calls of all function with a var in argument in a function *)
 let find_usesvar_in_fun_all funstrucname varname file =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun fundec _ ->
             Some
               (find_usesvar_in_fun "" fundec.svar.vid funstrucname varname file)))
@@ -281,7 +281,7 @@ let find_usesvar_in_fun_all funstrucname varname file =
 (* Finds all calls of a function with a var in argument in all functions *)
 let find_usesvar funname funid varname file =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun fundec _ ->
             Some
               (find_usesvar_in_fun funname funid fundec.svar.vname varname file)))
@@ -290,7 +290,7 @@ let find_usesvar funname funid varname file =
 (* Finds all calls of all functions with a var in argument in all functions *)
 let find_usesvar_all varname file =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun fundec _ ->
             Some (find_usesvar "" fundec.svar.vid varname file)))
        file.globals
@@ -331,7 +331,7 @@ let create_fun_res name id file loc =
 (* Finds all calls of a function in a condition in all functions *)
 let find_uses_cond funname funid file =
   let id_list = find_lval_of_calls funname funid file in
-  BatList.filter_map
+  Util.list_filter_map
     (fun (tmp, func) ->
       match FuncVar.find_uses_in_cond "" tmp file true with
       | (_, loc, _, _) :: _ -> Some (create_fun_res "" func file loc)
@@ -341,7 +341,7 @@ let find_uses_cond funname funid file =
 (* Finds all calls of all functions in a condition in all functions *)
 let find_uses_cond_all file =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun fundec _ -> Some (find_uses_cond "" fundec.svar.vid file)))
        file.globals
 
@@ -354,7 +354,7 @@ let find_uses_noncond funname funid file =
 (* Finds calls of all functions in non-condition in all functions *)
 let find_uses_noncond_all file =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun fundec _ ->
             Some (find_uses_noncond "" fundec.svar.vid file)))
        file.globals
@@ -397,7 +397,7 @@ let find_lval_of_calls_usesvar funname funid varname file =
 (* Finds calls of a function with a variable as argument in conditions *)
 let find_usesvar_cond funname funid varname file =
   let id_list = find_lval_of_calls_usesvar funname funid varname file in
-  BatList.filter_map
+  Util.list_filter_map
     (fun (tmp, func) ->
       match FuncVar.find_uses_in_cond "" tmp file true with
       | (_, loc, _, _) :: _ -> Some (create_fun_res "" func file loc)
@@ -407,7 +407,7 @@ let find_usesvar_cond funname funid varname file =
 (* Finds calls of all functions with a variable as argument in conditions *)
 let find_usesvar_cond_all varname file =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun fundec _ ->
             Some (find_usesvar_cond "" fundec.svar.vid varname file)))
        file.globals
@@ -421,7 +421,7 @@ let find_usesvar_noncond funname funid varname file =
 (* Finds calls of all functions with a variable as argument in non-conditions *)
 let find_usesvar_noncond_all varname file =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun fundec _ ->
             Some (find_usesvar_noncond "" fundec.svar.vid varname file)))
        file.globals

--- a/src/ext/syntacticsearch/funcVar.ml
+++ b/src/ext/syntacticsearch/funcVar.ml
@@ -28,12 +28,12 @@ let map_gvar f = function
 let is_temporary id = Inthash.mem allTempVars id
 
 let generate_func_loc_table cilfile =
-  BatList.filter_map
+  Util.list_filter_map
     (map_gfun (fun dec loc -> Some (dec.svar.vname, loc.line)))
     cilfile.globals
 
 let generate_globalvar_list cilfile =
-  BatList.filter_map
+  Util.list_filter_map
     (map_gvar (fun varinfo _ _ -> Some varinfo.vname))
     cilfile.globals
 
@@ -53,7 +53,7 @@ let get_all_alphaconverted_in_fun varname funname cilfile =
   in
   let loc_end = iter_fun_loc fun_loc_table in
   let tmp =
-    BatList.filter_map
+    Util.list_filter_map
       (function
         | EnvVar varinfo, loc when loc.line >= loc_start && loc.line < loc_end
           ->
@@ -223,7 +223,7 @@ let find_uses_in_fun_var dec name varid includeCallTmp cilfile =
 (* Finds the function in which a variable shall be found *)
 let find_uses_in_fun_find_fun list name varname varid includeCallTmp cilfile =
   let r =
-    BatList.find_opt
+    List.find_opt
       (function
         | GFun (dec, _) -> String.compare dec.svar.vname name = 0 | _ -> false)
       list
@@ -239,7 +239,7 @@ let find_uses_in_fun varname varid funname file includeCallTmp =
     file
 
 let find_all_glob_vars list =
-  BatList.filter_map (map_gvar (fun info _ _ -> Some info.vid)) list
+  Util.list_filter_map (map_gvar (fun info _ _ -> Some info.vid)) list
 
 (* Finds all uses of all global variables in a function *)
 let find_uses_in_fun_all_glob funname file includeCallTmp =
@@ -251,7 +251,7 @@ let find_uses_in_fun_all_glob funname file includeCallTmp =
 
 let find_fundec globals funname =
   let r =
-    BatList.find_opt
+    List.find_opt
       (function
         | GFun (dec, _) -> String.compare dec.svar.vname funname = 0
         | _ -> false)
@@ -274,7 +274,7 @@ let find_uses_in_fun_all funname file includeCallTmp =
 
 let find_var_in_globals varname varid list =
   let r =
-    BatList.find_opt
+    List.find_opt
       (function
         | GVar (info, _, _) -> is_equal_varname_varid info varname varid
         | _ -> false)
@@ -294,7 +294,7 @@ let find_var_in_globals varname varid list =
 let find_uses varname varid file includeCallTmp =
   let uses_in_all_fun =
     List.flatten
-    @@ BatList.filter_map
+    @@ Util.list_filter_map
          (map_gfun (fun dec _ ->
               Some
                 (find_uses_in_fun varname varid dec.svar.vname file
@@ -307,7 +307,7 @@ let find_uses varname varid file includeCallTmp =
 let find_uses_all_glob file includeCallTmp =
   let res =
     List.flatten
-    @@ BatList.filter_map
+    @@ Util.list_filter_map
          (map_gfun (fun dec _ ->
               Some
                 (find_uses_in_fun_all_glob dec.svar.vname file includeCallTmp)))
@@ -323,7 +323,7 @@ let find_uses_all_glob file includeCallTmp =
 let find_uses_all file includeCallTmp =
   let res =
     List.flatten
-    @@ BatList.filter_map
+    @@ Util.list_filter_map
          (map_gfun (fun dec _ ->
               Some (find_uses_in_fun_all dec.svar.vname file includeCallTmp)))
          file.globals
@@ -422,7 +422,7 @@ let find_uses_in_cond_in_fun_all funname file includeCallTmp =
 (* Finds all uses of variables in conditions in all functions *)
 let find_uses_in_cond_all file includeCallTmp =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun dec _ ->
             Some
               (find_uses_in_cond_in_fun_all dec.svar.vname file includeCallTmp)))
@@ -456,7 +456,7 @@ let find_uses_in_noncond_all file includeCallTmp =
 let find_decl_in_fun varname varid funname file =
   let get_formals_locals dec = dec.sformals @ dec.slocals in
   let iter_list_name list name =
-    BatList.filter_map
+    Util.list_filter_map
       (fun x ->
         if String.compare x.vname name = 0 && not (is_temporary x.vid) then
           Some
@@ -474,7 +474,7 @@ let find_decl_in_fun varname varid funname file =
   | None -> []
   | Some fundec ->
       if varid != -1 then
-        BatList.filter_map
+        Util.list_filter_map
           (fun x ->
             if x.vid = varid then
               Some
@@ -504,7 +504,7 @@ let find_decl_in_fun_all funname file =
 
 (* Finds all global variable declarations *)
 let find_decl_all_glob file =
-  BatList.filter_map
+  Util.list_filter_map
     (map_gvar (fun info _ loc ->
          Some
            ( info.vname,
@@ -536,7 +536,7 @@ let find_decl varname varid file =
 let find_decl_all file =
   let list =
     List.flatten
-    @@ BatList.filter_map
+    @@ Util.list_filter_map
          (map_gfun (fun dec _ ->
               Some (find_decl_in_fun_all dec.svar.vname file)))
          file.globals
@@ -588,7 +588,7 @@ let find_defs_in_fun varname varid funname file =
 (* Finds definitions of all global variables in a function *)
 let find_defs_in_fun_all_glob funname file =
   List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gvar (fun info _ _ ->
             Some (find_defs_in_fun "" info.vid funname file)))
        file.globals
@@ -610,7 +610,7 @@ let find_defs_in_fun_all funname file =
 let find_defs varname varid file =
   let r =
     List.flatten
-    @@ BatList.filter_map
+    @@ Util.list_filter_map
          (map_gfun (fun dec _ ->
               Some (find_defs_in_fun varname varid dec.svar.vname file)))
          file.globals
@@ -624,7 +624,7 @@ let find_defs_all_glob file =
        (fun x -> find_var_in_globals "" x file.globals)
        (find_all_glob_vars file.globals))
   @ List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun dec _ ->
             Some (find_defs_in_fun_all_glob dec.svar.vname file)))
        file.globals
@@ -636,6 +636,6 @@ let find_defs_all file =
        (fun x -> find_var_in_globals "" x file.globals)
        (find_all_glob_vars file.globals))
   @ List.flatten
-  @@ BatList.filter_map
+  @@ Util.list_filter_map
        (map_gfun (fun dec _ -> Some (find_defs_in_fun_all dec.svar.vname file)))
        file.globals

--- a/src/ocamlutil/util.ml
+++ b/src/ocamlutil/util.ml
@@ -60,3 +60,15 @@ let list_map_opt f = function
 
 let equals x1 x2 : bool =
   (compare x1 x2) = 0
+
+
+(* copied from OCaml Stdlib *)
+let list_filter_map f =
+  let rec aux accu = function
+    | [] -> List.rev accu
+    | x :: l ->
+        match f x with
+        | None -> aux accu l
+        | Some v -> aux (v :: accu) l
+  in
+  aux []

--- a/src/ocamlutil/util.mli
+++ b/src/ocamlutil/util.mli
@@ -20,3 +20,5 @@ val list_map_opt : ('a -> 'b) -> 'a list option -> 'b list option
    name or id in some field that occurs before any fields that have cyclic
    pointers. *)
 val equals: 'a -> 'a -> bool
+
+val list_filter_map: ('a -> 'b option) -> 'a list -> 'b list


### PR DESCRIPTION
Batteries is the only thing keeping us from OCaml 5 and its usage in CIL is ridiculously minimal: only `BatList.filter_map`.
Therefore this adds its implementation to an util module (OCaml >= 4.08 would have `List.filter_map`, but CIL supports >= 4.05 right now) and adds OCaml 5 alpha to the CI.