### PR TITLE
Support for `_Alignas(...)`

### DIFF
--- a/src/frontc/clexer.mll
+++ b/src/frontc/clexer.mll
@@ -184,6 +184,7 @@ let init_lexicon _ =
       ("__alignof", fun loc -> ALIGNOF loc);
       ("_Alignof", fun loc -> ALIGNOF loc);
       ("__alignof__", fun loc -> ALIGNOF loc);
+      ("_Alignas", fun loc -> ALIGNAS loc);
       ("__volatile__", fun loc -> VOLATILE loc);
       ("__volatile", fun loc -> VOLATILE loc);
       ("__real__", fun loc -> REAL loc);

--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -273,6 +273,7 @@ let transformOffsetOf (speclist, dtype) member =
 %token<Cabs.cabsloc> THREAD
 
 %token<Cabs.cabsloc> SIZEOF ALIGNOF
+%token<Cabs.cabsloc> ALIGNAS
 
 %token EQ PLUS_EQ MINUS_EQ STAR_EQ SLASH_EQ PERCENT_EQ
 %token AND_EQ PIPE_EQ CIRC_EQ INF_INF_EQ SUP_SUP_EQ
@@ -1051,6 +1052,8 @@ decl_spec_list_common:                  /* ISO 6.7 */
                                         /* ISO 6.7.4 */
 |   INLINE decl_spec_list_opt           { SpecInline :: $2, $1 }
 |   NORETURN decl_spec_list_opt         { SpecNoreturn  :: $2, $1 }
+|   ALIGNAS LPAREN expression RPAREN decl_spec_list_opt { $5, $1 }
+|   ALIGNAS LPAREN type_name RPAREN decl_spec_list_opt { $5, $1 }
 
 |   cvspec decl_spec_list_opt           { (fst $1) :: $2, snd $1 }
 /* specifier pattern variable (must be last in spec list) */

--- a/test/small1/alignas.c
+++ b/test/small1/alignas.c
@@ -1,0 +1,11 @@
+#include <stdalign.h>
+
+struct XXH3_state_s {
+    _Alignas(int) unsigned char customSecret1[25];
+    _Alignas(64) unsigned char customSecret2[25];
+    alignas(64) unsigned char customSecret3[25];
+};
+
+int main() {
+
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -724,6 +724,7 @@ addTestFail("testc11/gcc-c11-generic-3-4", "No compatible associations or defaul
 addTestFail("testc11/clang-c11-generic-1-1", "Multiple compatible associations in generic");
 addTestFail("testc11/clang-c11-generic-1-2", "No compatible associations or default in generic");
 addTest("testc11/clang-c11-generic-2");
+addTest("testc11/alignas");
 
 # ---------------- c-torture -------------
 ## if we have the c-torture tests add them


### PR DESCRIPTION
This adds support for `_Alignas(expr)` and `_Alignas(type-name)` from the C11 standard.

Currently, while this information is parsed it is not represented in the corresponding Cabs or CIL ASTs.

References #13.
Closes #93.