### PR TITLE
Allow casts from any type to `void`

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -1416,7 +1416,7 @@ let rec castTo ?(fromsource=false)
         result
 
           (* The expression is evaluated for its side-effects *)
-    | (TInt _ | TEnum _ | TPtr _ ), TVoid _ ->
+    | _ , TVoid _ ->
         (ot, e)
 
           (* Even casts between structs are allowed when we are only

--- a/test/small1/c99-tgmath2.c
+++ b/test/small1/c99-tgmath2.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <tgmath.h>
+#include <complex.h>
+#include "testharness.h"
+
+typedef struct loc_t
+{
+  long nloc;
+} loc_t;
+
+
+void fun(const loc_t* loc) {
+    long l;
+    int n0 =(int)sqrt(l); // works
+    int n1 =(int)sqrt(loc->nloc); // fails
+}
+
+
+int main() {
+  loc_t loc;
+  loc.nloc = 5;
+  loc_t* ptr = &loc;
+  fun(ptr);
+}

--- a/test/small1/c99-tgmath2.c
+++ b/test/small1/c99-tgmath2.c
@@ -10,7 +10,7 @@ typedef struct loc_t
 
 
 void fun(const loc_t* loc) {
-    long l;
+    long l =8;
     int n0 =(int)sqrt(l); // works
     int n1 =(int)sqrt(loc->nloc); // fails
 }
@@ -21,4 +21,5 @@ int main() {
   loc.nloc = 5;
   loc_t* ptr = &loc;
   fun(ptr);
+  SUCCESS;
 }

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -695,6 +695,7 @@ addTest("testrunc99/c99-complex");
 addTest("testrunc99/c99-universal-character-names");
 
 addTest("testrunc99/c99-tgmath");
+addTest("testrunc99/c99-tgmath2");
 addTest("testrunc99/c99-float-pragma");
 addTest("testrunc99/c99-fixed-width-int");
 addTest("combinec99inline");


### PR DESCRIPTION
Any expression may be cast to `void` according to the standard if an expression is only evaluated for its side-effects. We currently limit this to `(TInt _ | TEnum _ | TPtr _ )` for some reason.

Closes #91 