### PR TITLE
Fix scope of enum definition in return type

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -6018,24 +6018,25 @@ and doDecl (isglobal: bool) : A.definition -> chunk = function
                };
 	    !currentFunctionFDEC.svar.vdecl <- funloc;
 
-            (* Setup the environment. Add the formals to the locals. Maybe
-              they need alpha-conv  *)
-            enterScope ();  (* Start the scope *)
-
-            IH.clear varSizeArrays;
-
-            (* Enter all the function's labels into the alpha conversion table *)
-            ignore (V.visitCabsBlock (new registerLabelsVisitor) body);
-            currentLoc := funloc; (* registerLabelsVisitor changes currentLoc, so reset it *)
-            (* Visitor doesn't use and touch currentExpLoc, so no need to reset. *)
-
-            (* Do not process transparent unions in function definitions.
-              We'll do it later *)
-            transparentUnionArgs := [];
-
             (* Fix the NAME and the STORAGE *)
             let _ =
               let bt,sto,inl,attrs = doSpecList n specs in
+
+              (* Setup the environment. Add the formals to the locals. Maybe
+                they need alpha-conv  *)
+              enterScope ();  (* Start the scope *)
+              (* Scope must be started after doSpecList, which adds enum values declared in return type to outer scope! *)
+
+              IH.clear varSizeArrays;
+
+              (* Enter all the function's labels into the alpha conversion table *)
+              ignore (V.visitCabsBlock (new registerLabelsVisitor) body);
+              currentLoc := funloc; (* registerLabelsVisitor changes currentLoc, so reset it *)
+              (* Visitor doesn't use and touch currentExpLoc, so no need to reset. *)
+
+              (* Do not process transparent unions in function definitions.
+                We'll do it later *)
+              transparentUnionArgs := [];
               !currentFunctionFDEC.svar.vinline <- inl;
 
               let ftyp, funattr =

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -1211,10 +1211,6 @@ class registerLabelsVisitor = object
     V.DoChildren
 end
 
-(* Maps local variables that are variable sized arrays to the expression that
-   denotes their length *)
-let varSizeArrays : exp IH.t = IH.create 17
-
 (**** EXP actions ***)
 type expAction =
     ADrop                               (* Drop the result. Only the
@@ -3738,12 +3734,6 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
                    mean the pointer to the start of the string *)
           | Const(CStr _) -> SizeOf (charPtrType)
 
-                (* Maybe we are taking the sizeof a variable-sized array *)
-          | Lval (Var vi, NoOffset) -> begin
-              try
-                IH.find varSizeArrays vi.vid
-              with Not_found -> SizeOfE e'
-          end
           | _ -> SizeOfE e'
         in
         finishExp empty size !typeOfSizeOf
@@ -6026,8 +6016,6 @@ and doDecl (isglobal: bool) : A.definition -> chunk = function
                 they need alpha-conv  *)
               enterScope ();  (* Start the scope *)
               (* Scope must be started after doSpecList, which adds enum values declared in return type to outer scope! *)
-
-              IH.clear varSizeArrays;
 
               (* Enter all the function's labels into the alpha conversion table *)
               ignore (V.visitCabsBlock (new registerLabelsVisitor) body);

--- a/test/small1/enum-scope.c
+++ b/test/small1/enum-scope.c
@@ -1,0 +1,12 @@
+enum {A, B, C} foo() {
+  return A;
+}
+
+void bar() {
+  if (foo() == A) {
+  }
+}
+
+int main() {
+  return 0;
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -254,6 +254,7 @@ addTest("testrun/const16 ");
 addTest("test/deref _GNUCC=1");
 addTest("test_i/empty");
 addTest("test/enum");
+addTest("test/enum-scope");
 addTest("testrun/enum2");
 addTest("test/func");
 addTest("test/funcarg ");


### PR DESCRIPTION
Closes #112.

Just moves `enterScope` and a bunch of other things after `doSpecList` inside which the return type is handled. Apparently definitions inside that are still in the outer (global) scope according to the standard.

Also removes `Cabs2cil.varSizeArrays`, which was never added to, so it was always empty anyway.

This fixes parsing of curl and masscan.