### PR TITLE
Optimize big int powers of 2

### DIFF
--- a/src/cilint.ml
+++ b/src/cilint.ml
@@ -22,7 +22,7 @@ let one_cilint = unit_big_int
 let mone_cilint = minus_big_int unit_big_int
 
 (* Precompute useful big_ints *)
-let b30 = power_int_positive_int 2 30
+let b30 = shift_left_big_int unit_big_int 30
 let m1 = minus_big_int unit_big_int
 
 (* True if 'b' is all 0's or all 1's *)
@@ -107,16 +107,17 @@ let logand_cilint = logop (land)
 let logor_cilint = logop (lor)
 let logxor_cilint = logop (lxor)
 
-let shift_right_cilint (c1:cilint) (n:int) : cilint = div_big_int c1 (power_int_positive_int 2 n)
+let shift_right_cilint (c1:cilint) (n:int) : cilint =
+  shift_right_towards_zero_big_int c1 n
 
 let shift_left_cilint (c1:cilint) (n:int) : cilint =
-  mult_big_int c1 (power_int_positive_int 2 n)
+  shift_left_big_int c1 n
 
 let lognot_cilint (c1:cilint) : cilint = (pred_big_int (minus_big_int c1))
 
 let truncate_signed_cilint (c:cilint) (n:int) : cilint * truncation =
-  let max = power_int_positive_int 2 (n - 1) in
-  let truncmax = power_int_positive_int 2 n in
+  let max = shift_left_big_int unit_big_int (n - 1) in
+  let truncmax = shift_left_big_int unit_big_int n in
   let bits = mod_big_int c truncmax in
   let tval = if lt_big_int bits max then
 	    bits
@@ -135,8 +136,8 @@ let truncate_signed_cilint (c:cilint) (n:int) : cilint * truncation =
     tval, trunc
 
 let truncate_unsigned_cilint (c:cilint) (n:int) : cilint * truncation =
-  let max = power_int_positive_int 2 (n - 1) in
-  let truncmax = power_int_positive_int 2 n in
+  let max = shift_left_big_int unit_big_int (n - 1) in
+  let truncmax = shift_left_big_int unit_big_int n in
   let bits = mod_big_int c truncmax in
   let trunc =
     if ge_big_int c truncmax || lt_big_int c zero_big_int then


### PR DESCRIPTION
While profiling I noticed `Cil.truncateCilint` taking unusually much time computing these powers. In most cases this probably makes no difference but in the case where I noticed this, it was ~10% of the time. The truncation function is indirectly involved in a number of CIL things, including constant folding.

Microbenchmarks confirm that using left shifts to compute these powers is 5 to 182 _times_ faster, depending on the shift amount:

<details>

```
*** Run benchmarks for path "pow2.16"

Throughputs for "pow", "lsl" each running for at least 1 CPU second:
pow:  1.06 WALL ( 1.06 usr +  0.00 sys =  1.06 CPU) @ 10647729.73/s (n=11324180)
lsl:  1.06 WALL ( 1.06 usr +  0.00 sys =  1.06 CPU) @ 1000373484.85/s (n=1057141679)
            Rate   pow   lsl
pow   10647730/s    --  -99%
lsl 1000373485/s 9295%    --
**********************************************************************
*** Run benchmarks for path "pow2.32"

Throughputs for "pow", "lsl" each running for at least 1 CPU second:
pow:  1.05 WALL ( 1.05 usr +  0.00 sys =  1.05 CPU) @ 10584764.32/s (n=11103259)
lsl:  1.08 WALL ( 1.08 usr +  0.00 sys =  1.08 CPU) @ 1944034412.17/s (n=2095989862)
            Rate    pow    lsl
pow   10584764/s     --   -99%
lsl 1944034412/s 18266%     --
**********************************************************************
*** Run benchmarks for path "pow2.64"

Throughputs for "pow", "lsl" each running for at least 1 CPU second:
pow:  1.06 WALL ( 1.06 usr +  0.00 sys =  1.06 CPU) @ 10889459.96/s (n=11519437)
lsl:  1.04 WALL ( 1.03 usr +  0.00 sys =  1.03 CPU) @ 74028830.75/s (n=76530413)
          Rate  pow  lsl
pow 10889460/s   -- -85%
lsl 74028831/s 580%   --
**********************************************************************
*** Run benchmarks for path "pow2.8"

Throughputs for "pow", "lsl" each running for at least 1 CPU second:
pow:  1.07 WALL ( 1.06 usr +  0.00 sys =  1.06 CPU) @ 10730495.05/s (n=11409671)
lsl:  1.15 WALL ( 1.15 usr +  0.00 sys =  1.15 CPU) @ 1461986354.64/s (n=1684910034)
            Rate    pow    lsl
pow   10730495/s     --   -99%
lsl 1461986355/s 13525%     --
```

</details>