### PR TITLE
Fix FrontC and Cabs2cil partial application

### DIFF
--- a/src/frontc/frontc.ml
+++ b/src/frontc/frontc.ml
@@ -255,15 +255,17 @@ let parse_helper fname =
   (trace "sm" (dprintf "parsing %s to Cabs\n" fname));
   let cabs = parse_to_cabs fname in
   (* Now (return a function that will) convert to CIL *)
-  fun _ ->
+  fun () ->
     (trace "sm" (dprintf "converting %s from Cabs to CIL\n" fname));
     let cil = Stats.time "convert to CIL" Cabs2cil.convFile cabs in
     if !doPrintProtos then (printPrototypes cabs);
     cabs, cil
 
-let parse fname = (fun () -> snd(parse_helper fname ()))
+let parse fname =
+  let cabs2cil = parse_helper fname in
+  fun () -> snd (cabs2cil ())
 
-let parse_with_cabs fname = (fun () -> parse_helper fname ())
+let parse_with_cabs fname = parse_helper fname
 
 let parse_standalone_exp s =
   try


### PR DESCRIPTION
Documentation promises partial application just does FrontC and returned closure does Cabs2cil:
https://github.com/goblint/cil/blob/729a1ff3f300330043af118141229079e0fad499/src/frontc/frontc.mli#L48-L52

However, this was implemented incorrectly: `parse_helper` wasn't partially applied immediately, but only when fully applied and then did both together.

This will allow Goblint to have an improved `Stats` module while still measuring the two phases separately.