### PR TITLE
Expose `populateLabelAlphaTable`

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -6735,6 +6735,7 @@ let findAddrOfLabelStmts (b : block) : stmt list =
 
 (* Clears the labelAlphaTable and populates it with all label names appearing in fd *)
 let populateLabelAlphaTable (fd: fundec): unit =
+  H.clear labelAlphaTable;
   ignore (visitCilFunction (new registerLabelsVisitor) fd)
 
 (* prepare a function for computeCFGInfo by removing break, continue,

--- a/src/cil.mli
+++ b/src/cil.mli
@@ -2665,8 +2665,11 @@ val endsWith: string -> string -> bool
 (** If string has leading and trailing __, strip them. *)
 val stripUnderscores: string -> string
 
-(** To generate new labels which do not provoke collision *)
+(** To generate new labels which do not provoke collision, call {!populateLabelAlphaTable} for the corresponding fundec before *)
 val freshLabel: string -> string
+
+(** Clears the labelAlphaTable and populates it with all label names appearing in the fundec. Needs to be called before {!freshLabel} *)
+val populateLabelAlphaTable: fundec -> unit
 
 (** {b An Interpreter for constructing CIL constructs} *)
 


### PR DESCRIPTION
This needs to be called before `Cil.freshLabel` can be used to obtain a label that is guaranteed to be unique within an already existing fundec (passed to `populateLabelAlphaTable` as an argument).

Needed to implement loop unrolling in Goblint (https://github.com/goblint/analyzer/pull/896).