### PR TITLE
Only constant fold for `shitfleft` when defined

### DIFF
--- a/test/small1/constfold2.c
+++ b/test/small1/constfold2.c
@@ -1,0 +1,9 @@
+#include "testharness.h"
+int main()
+{
+    /* We check that with warnings as errors this fails also after CIL */
+    int displayMask = 1 << 31;
+    displayMask = 0;
+
+    return displayMask;
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -616,6 +616,9 @@ addTest("combinegnuinline");
 addTest("testrun/constfold EXTRAARGS=\"--domakeCFG --dopartial\"");
 addBadComment("testrun/constfold", "Bug. Wrong constant folding.  #2276515 on sourceforge.");
 
+# Check that CIL does not do constant folding in cases where it is undefined
+addTestFail("testrun/constfold2 EXTRAARGS=\"--domakeCFG -Wall -Wshift-overflow=3 -Werror\"", "constfold should not remove undefined behavior");
+
 # tests of things implemented for EDG compatibility
 addTest("mergestruct");
 


### PR DESCRIPTION
This removes some constant folding for `shiftleft` that hide potential undefined behavior for signed types.

Closes #122 