### PR TITLE
Make more loop statement locations synthetic

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -6684,8 +6684,8 @@ and doStatement (s : A.statement) : chunk =
         let eloc' = convLoc eloc in
         let break_cond = breakChunk loc' in (* TODO: use eloc'? *)
         exitLoop ();
-        currentLoc := loc';
-        currentExpLoc := eloc';
+        currentLoc := {loc' with synthetic = true};
+        currentExpLoc := {eloc' with synthetic = true};
         loopChunk ((doCondition false e skipChunk break_cond)
                    @@ s')
 
@@ -6694,8 +6694,8 @@ and doStatement (s : A.statement) : chunk =
         let s' = doStatement s in
         let loc' = convLoc loc in
         let eloc' = convLoc eloc in
-        currentLoc := loc';
-        currentExpLoc := eloc';
+        currentLoc := {loc' with synthetic = true};
+        currentExpLoc := {eloc' with synthetic = true};
         let s'' =
           consLabContinue (doCondition false e skipChunk (breakChunk loc')) (* TODO: use eloc'? *)
         in


### PR DESCRIPTION
### Changes
1. Make `for` loop initializer and incrementer statement locations synthetic, because they aren't valid locations for inserting assertions.
2. Make `while` and `do`-`while` loop condition locations synthetic, because assertions can't be inserted at the loop head.
3. Refactor location synthetization.