### PR TITLE
Fix lib/perl5/patcher

### DIFF
--- a/lib/perl5/patcher
+++ b/lib/perl5/patcher
@@ -243,7 +243,10 @@ sub patchOneFile {
 	}
     } else { die "Invalid --mode"; }
 
-    # Now scan the resulting file and get the real name of the file
+	system($preproccmd);
+    # For some reason the gcc returns spurious error codes
+
+	# Now scan the resulting file and get the real name of the file
     my $absname = "";
     open(PPOUT, "<$preprocfile.i") || die "Cannot find $preprocfile.i";
     while(<PPOUT>) {


### PR DESCRIPTION
I'm not currently using the patcher, but I was trying it out (seems right for patching some OCaml runtime headers for a cusotm CIL analysis) and noticed it wasn't actually working. Looks like a previous patch to remove MSVC was a bit too eager, and actually removed the line that runs the preprocessor. Restore it with this patch.

Commit b01b40430 has removed MSVC, but also removed the 'system' line, which was important for its side effect of running the preprocessor (even if the body of the if would never be entered with GCC)

Fixes: b01b40430 ("Remove remaining MSVC things")

Tested with:
```
$ perl -I$(opam var lib)/perl5 lib/perl5/patcher --patch=mypatch.cillypatch --dest=destpatch --ufile caml/misc.h --verbose --mode=GNUCC -I$(ocamlc -where)
Patching files for GNU CC version gcc_11
Loaded patches from mypatch.cillypatch
Patching "caml/misc.h"
   Absolute name is /home/edwin/.opam/4.14.0/lib/ocaml/caml/misc.h
   Destination is destpatch/gcc_11/caml/misc.h
```

With the following mypatch.cillypatch as a test:
```
<<<<
 #define CAMLprim
====
 #define CAMLprim foo
>>>>
```

And the patcher has performed the following modification:
```
diff -wu /home/edwin/.opam/4.14.0/lib/ocaml/caml/misc.h destpatch/gcc_11/caml/misc.h
--- /home/edwin/.opam/4.14.0/lib/ocaml/caml/misc.h	2022-08-23 09:48:26.263777010 +0100
+++ destpatch/gcc_11/caml/misc.h	2023-01-03 14:25:59.180139744 +0000
@@ -121,7 +121,9 @@
 #endif

 #define CAMLexport
-#define CAMLprim
+#line 4 "mypatch.cillypatch"
+#define CAMLprim foo
+#line 125 "/home/edwin/.opam/4.14.0/lib/ocaml/caml/misc.h"
 #define CAMLextern CAMLDLLIMPORT extern

 /* Weak function definitions that can be overridden by external libs */
```
