### PR TITLE
Add `return` statements in `noreturn` functions

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -88,6 +88,8 @@ let useComputedGoto = ref false
 
 let useCaseRange = ref false
 
+let addReturnOnNoreturnFallthrough = ref false
+
 module M = Machdep
 (* Cil.initCil will set this to the current machine description.
    Makefile.cil generates the file src/machdep.ml,

--- a/src/cil.mli
+++ b/src/cil.mli
@@ -57,6 +57,7 @@ type cstd = C90 | C99 | C11
 val cstd_of_string: string -> cstd
 val cstd: cstd ref
 val gnu89inline: bool ref
+val addReturnOnNoreturnFallthrough: bool ref
 
 (** This module defines the abstract syntax of CIL. It also provides utility
    functions for traversing the CIL data structures, and pretty-printing

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -6437,8 +6437,14 @@ and doDecl (isglobal: bool) : A.definition -> chunk = function
                     ignore (warn "Body of function %s falls-through and cannot find an appropriate return value" !currentFunctionFDEC.svar.vname);
                     None
               in
-              if not (hasAttribute "noreturn"
-                        !currentFunctionFDEC.svar.vattr) then
+              if
+                (* By default, (addReturnOnNoreturnFallthrough = false), CIL does not add a return statement
+                  in functions marked noreturn. However, unlike functions that are detected to never fall through,
+                  the end of these functions can possibly be reached (perhaps in buggy program code), so with
+                  the option set to true, always add the return statement. *)
+                !addReturnOnNoreturnFallthrough
+                || not (hasAttribute "noreturn" !currentFunctionFDEC.svar.vattr)
+              then
                 !currentFunctionFDEC.sbody.bstmts <-
                   !currentFunctionFDEC.sbody.bstmts
                   @ [mkStmt (Return(retval, endloc))]


### PR DESCRIPTION
(Option to) add always add return statements in functions that fall through, specifically those marked `noreturn`. The justification for adding this change to CIL: currently CIL always adds a return statement if it is at all possible for the function to reach the end of its body. For `noreturn` functions, however, it trusts that these functions never reach their end. This makes the behaviour arguably more consistent between functions marked `noreturn` and functions that are not.

Fixes https://github.com/goblint/analyzer/issues/951. Fixes the issue blocking https://github.com/goblint/analyzer/pull/953. See also https://github.com/goblint/analyzer/pull/953#issuecomment-1403944222.