### PR TITLE
Respect C11 `_Alignas(...)` for computing alignments

### DIFF
--- a/src/frontc/cparser.mly
+++ b/src/frontc/cparser.mly
@@ -1052,8 +1052,8 @@ decl_spec_list_common:                  /* ISO 6.7 */
                                         /* ISO 6.7.4 */
 |   INLINE decl_spec_list_opt           { SpecInline :: $2, $1 }
 |   NORETURN decl_spec_list_opt         { SpecNoreturn  :: $2, $1 }
-|   ALIGNAS LPAREN expression RPAREN decl_spec_list_opt { $5, $1 }
-|   ALIGNAS LPAREN type_name RPAREN decl_spec_list_opt { $5, $1 }
+|   ALIGNAS LPAREN expression RPAREN decl_spec_list_opt { SpecAttr ("aligned", [fst $3]) :: $5, $1 }
+|   ALIGNAS LPAREN type_name RPAREN decl_spec_list_opt { let b, d = $3 in SpecAttr ("aligned", [ TYPE_ALIGNOF (b, d) ]) :: $5, $1 }
 
 |   cvspec decl_spec_list_opt           { (fst $1) :: $2, snd $1 }
 /* specifier pattern variable (must be last in spec list) */

--- a/test/small1/alignas_proper.c
+++ b/test/small1/alignas_proper.c
@@ -1,0 +1,26 @@
+#include <stdalign.h>
+
+struct testalign {
+  int f1;
+} __attribute__((__aligned__(16)));
+
+struct testalign2 {
+  _Alignas(16) int f1;
+};
+
+struct testalign3 {
+  _Alignas(long double) int f1;
+};
+
+
+int main() {
+  struct testalign a;
+  char static_assertion_failure_1[(__alignof__ (a) == 16) ? 1 : -1];
+
+  struct testalign2 b;
+  char static_assertion_failure_2[(__alignof__ (b) == 16) ? 1 : -1];
+
+  struct testalign3 c;
+  char static_assertion_failure_3[(__alignof__ (c) == __alignof__ (long double)) ? 1 : -1];
+  return 0;
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -747,6 +747,7 @@ addTestFail("testc11/clang-c11-generic-1-1", "Multiple compatible associations i
 addTestFail("testc11/clang-c11-generic-1-2", "No compatible associations or default in generic");
 addTest("testc11/clang-c11-generic-2");
 addTest("testc11/alignas");
+addTest("testc11/alignas_proper");
 
 # ---------------- c-torture -------------
 ## if we have the c-torture tests add them


### PR DESCRIPTION
While we added support for `_Alignas(...)` to the parser as part of #108, we did not propagate this through Cabs into CIL, leading to alignment computation ignoring `_Alignas(...)` there.
 
This PR fixes the issue by mapping `_Alignas(...)` to the appropriate GCC extension in the parser that is already correctly supported.
 
 Thanks again @edwintorok for reporting! (https://github.com/goblint/cil/issues/13#issuecomment-1359176037)