### PR TITLE
Fix `Pretty` not resetting all global state between calls

### DIFF
--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -566,6 +566,7 @@ let emitDoc
 let fprint (chn: out_channel) ~(width: int) doc =
   let doc = if !flattenBeforePrint then flatten Nil doc else doc in
   (* Save some parameters, to allow for nested calls of these routines. *)
+  let old_maxCol = !maxCol in
   maxCol := width;
   let old_breaks = !breaks in
   breaks := [];
@@ -573,6 +574,12 @@ let fprint (chn: out_channel) ~(width: int) doc =
   alignDepth := 0;
   let old_activeMarkups = !activeMarkups in
   activeMarkups := [];
+  let old_aligns = !aligns in
+  aligns := [{ gainBreak = 0; isTaken = ref false; deltaFromPrev = ref 0; deltaToNext = ref 0; }];
+  let old_topAlignAbsCol = !topAlignAbsCol in
+  topAlignAbsCol := 0;
+  let old_breakAllMode = !breakAllMode in
+  breakAllMode := false;
   ignore (scan 0 doc);
   breaks := List.rev !breaks;
   ignore (emitDoc
@@ -580,15 +587,20 @@ let fprint (chn: out_channel) ~(width: int) doc =
               for _ = 1 to nrcopies do
                 output_string chn s
               done) doc);
+  breakAllMode := old_breakAllMode;
+  topAlignAbsCol := old_topAlignAbsCol;
+  aligns := old_aligns;
   activeMarkups := old_activeMarkups;
   alignDepth := old_alignDepth;
-  breaks := old_breaks (* We must do this especially if we don't do emit
+  breaks := old_breaks; (* We must do this especially if we don't do emit
                           (which consumes breaks) because otherwise we waste
                           memory *)
+  maxCol := old_maxCol
 
 (* Print the document to a string *)
 let sprint ~(width : int)  doc : string =
   let doc = if !flattenBeforePrint then flatten Nil doc else doc in
+  let old_maxCol = !maxCol in
   maxCol := width;
   let old_breaks = !breaks in
   breaks := [];
@@ -596,6 +608,12 @@ let sprint ~(width : int)  doc : string =
   activeMarkups := [];
   let old_alignDepth = !alignDepth in
   alignDepth := 0;
+  let old_aligns = !aligns in
+  aligns := [{ gainBreak = 0; isTaken = ref false; deltaFromPrev = ref 0; deltaToNext = ref 0; }];
+  let old_topAlignAbsCol = !topAlignAbsCol in
+  topAlignAbsCol := 0;
+  let old_breakAllMode = !breakAllMode in
+  breakAllMode := false;
   ignore (scan 0 doc);
   breaks := List.rev !breaks;
   let buf = Buffer.create 1024 in
@@ -604,9 +622,13 @@ let sprint ~(width : int)  doc : string =
     else begin Buffer.add_string buf str; add_n_strings str (num - 1) end
   in
   emitDoc add_n_strings doc;
+  breakAllMode := old_breakAllMode;
+  topAlignAbsCol := old_topAlignAbsCol;
+  aligns := old_aligns;
   breaks  := old_breaks;
   activeMarkups := old_activeMarkups;
   alignDepth := old_alignDepth;
+  maxCol := old_maxCol;
   Buffer.contents buf
 
 


### PR DESCRIPTION
This fixes the long-standing oddity where Goblint prints warnings like
```
[Info][Imprecise] Invalidating expressions: AddrOf(Var(tmp,
                                     NoOffset)) (tests/regression/04-mutex/13-failed_locking.c:20:7-20:34)
```
despite using `Pretty.sprint ~width:max_int`, which should avoid such random line breaks.

The specific problem was that `Pretty.breakAllMode` was not being reset between different `Pretty` calls, so when it became active, following pretty-printing had such odd line breaks.

There were two more global variables in `Pretty` which were not being reset: `topAlignAbsCol` and `aligns`.
Now all global variables in `Pretty` are reset and restored properly.