### PR TITLE
Fix `TCompLoop` printing being stateful

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -4622,13 +4622,16 @@ class plainCilPrinterClass =
            self#pAttrs comp.cattr
        else begin
          H.add donecomps comp.ckey (); (* Add it before we do the fields *)
-         dprintf "TComp(@[%s %s,@?%a,@?%a,@?%a@])"
+         let doc = dprintf "TComp(@[%s %s,@?%a,@?%a,@?%a@])"
            (if comp.cstruct then "struct" else "union") comp.cname
            (docList ~sep:(chr ',' ++ break)
               (fun f -> dprintf "%s : %a" f.fname self#pOnlyType f.ftype))
            comp.cfields
            self#pAttrs comp.cattr
            self#pAttrs a
+         in
+         H.remove donecomps comp.ckey; (* Remove it after we do the fields, so printer doesn't have global state *)
+         doc
        end
    | TBuiltin_va_list a ->
        dprintf "TBuiltin_va_list(%a)" self#pAttrs a


### PR DESCRIPTION
Previously when using `d_plaintype` (or any other plain printing which includes the type) twice in a row on a recursive struct, the first output has `TComp` outside and `TCompLoop` on the fields:
```
TPtr(TComp(struct __pthread_internal_list,
              __prev : TPtr(TCompLoop(struct __pthread_internal_list, _, ), ),
              __next : TPtr(TCompLoop(struct __pthread_internal_list, _, ), ), ,
        ), )
```
Due to the statefulness of the plain printer, a second call with exactly the same type already has `TCompLoop` outside:
```
TPtr(TCompLoop(struct __pthread_internal_list, _, ), )
```

This is annoying for incremental analysis in Goblint, where messages will differ only in this aspect because the incremental run will skip over some earlier evaluation that made the first call, moving the first call with the different output to a different place. It shows spurious differences in `messagesCompare`.

By removing the `compinfo` after recursing, the plain printer becomes functionally pure, so all calls consistently print the first output from above.