### PR TITLE
Add parsing support for 'asm goto'

### DIFF
--- a/src/cil.mli
+++ b/src/cil.mli
@@ -1049,6 +1049,7 @@ and instr =
                   (string option * string * exp) list *
                                         (* inputs with optional names and constraints *)
                   string list *         (* register clobbers *)
+                  string list *         (* GoToLabels *)
                   location
     (** There are for storing inline assembly. They follow the GCC
         specification:

--- a/src/ext/liveness/usedef.ml
+++ b/src/ext/liveness/usedef.ml
@@ -150,7 +150,7 @@ class useDefVisitorClass : cilVisitor = object (self)
         E.s (bug "bad call to %s" vi.vname)
     | Call (lvo, f, args, _, _) ->
         doCall f lvo args
-    | Asm(_,_,slvl,_,_,_) -> List.iter (fun (_,s,lv) ->
+    | Asm(_,_,slvl,_,_,_,_) -> List.iter (fun (_,s,lv) ->
 	match lv with (Var v, off) ->
 	  if s.[0] = '+' then
 	    varUsed := VS.add v !varUsed;

--- a/src/ext/zrapp/availexps.ml
+++ b/src/ext/zrapp/availexps.ml
@@ -243,7 +243,7 @@ let eh_handle_inst i eh =
       (eh_kill_mem eh;
        eh_kill_addrof_or_global eh;
        eh)
-  | Asm(_,_,_,_,_,_) ->
+  | Asm(_,_,_,_,_,_,_) ->
       let _,d = UD.computeUseDefInstr i in
       (UD.VS.iter (fun vi ->
 	eh_kill_vi eh vi) d;

--- a/src/ext/zrapp/availexpslv.ml
+++ b/src/ext/zrapp/availexpslv.ml
@@ -305,7 +305,7 @@ let lvh_handle_inst i lvh =
       end;
       lvh
   end
-  | Asm(_,_,_,_,_,_) -> begin
+  | Asm(_,_,_,_,_,_,_) -> begin
       let _,d = UD.computeUseDefInstr i in
       UD.VS.iter (fun vi ->
 	lvh_kill_vi lvh vi) d;

--- a/src/ext/zrapp/deadcodeelim.ml
+++ b/src/ext/zrapp/deadcodeelim.ml
@@ -102,7 +102,7 @@ class usedDefsCollectorClass = object(self)
 
   method! vinst i =
     let handle_inst iosh i = match i with
-    | Asm(_,_,slvl,_,_,_) -> List.iter (fun (_,s,lv) ->
+    | Asm(_,_,slvl,_,_,_,_) -> List.iter (fun (_,s,lv) ->
 	match lv with (Var v, off) ->
 	  if s.[0] = '+' then
 	    self#add_defids iosh (Lval(Var v, off)) (UD.VS.singleton v)

--- a/src/ext/zrapp/reachingdefs.ml
+++ b/src/ext/zrapp/reachingdefs.ml
@@ -270,7 +270,7 @@ let getDefRhs didstmh stmdat defId =
 		Set((Var vi',NoOffset),_,_,_) -> vi'.vid = vid (* _ -> NoOffset *)
 	      | Call(Some(Var vi',NoOffset),_,_,_,_) -> vi'.vid = vid (* _ -> NoOffset *)
 	      | Call(None,_,_,_,_) -> false
-	      | Asm(_,_,sll,_,_,_) -> List.exists
+	      | Asm(_,_,sll,_,_,_,_) -> List.exists
 		    (function (_,_,(Var vi',NoOffset)) -> vi'.vid = vid | _ -> false) sll
 	      | _ -> false)
 	  | None -> false) iihl in
@@ -284,7 +284,7 @@ let getDefRhs didstmh stmdat defId =
 	| Call(lvo,e,el,_,_) ->
 	    (IH.add rhsHtbl defId (Some(RDCall(i),stm.sid,iosh_in));
 	     Some(RDCall(i), stm.sid, iosh_in))
-	| Asm(a,sl,slvl,sel,sl',_) -> None
+	| Asm(a,sl,slvl,sel,sl',_,_) -> None
   | VarDecl _ -> None
   ) (* ? *)
 	with Not_found ->

--- a/src/ext/zrapp/rmciltmps.ml
+++ b/src/ext/zrapp/rmciltmps.ml
@@ -994,7 +994,7 @@ class unusedRemoverClass : cilVisitor = object(self)
 	  (match IH.find iioh vi.vid with
 	    None -> true | Some _ -> false)
       end
-      | Asm(_,_,slvlst,_,_,_) -> begin
+      | Asm(_,_,slvlst,_,_,_,_) -> begin
 	  (* make sure the outputs are in the locals list *)
 	  List.iter (fun (_,s,lv) ->
 	    match lv with (Var vi,_) ->

--- a/src/frontc/cabs.ml
+++ b/src/frontc/cabs.ml
@@ -209,7 +209,8 @@ and block =
 and asm_details =
     { aoutputs: (string option * string * expression) list; (* optional name, constraints and expressions for outputs *)
       ainputs: (string option * string * expression) list; (* optional name, constraints and expressions for inputs *)
-      aclobbers: string list (* clobbered registers *)
+      aclobbers: string list; (* clobbered registers *)
+      agotolabels: string list; (* GoToLabels *)
     }
 
 and statement =

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -822,7 +822,7 @@ module BlockChunk =
         | Set (l, e, loc, eloc) -> Set (l, e, doLoc loc, doLoc eloc)
         | VarDecl (v, loc) -> VarDecl (v, doLoc loc)
         | Call (l, f, a, loc, eloc) -> Call (l, f, a, doLoc loc, doLoc eloc)
-        | Asm (a, b, c, d, e, loc) -> Asm (a, b, c, d, e, doLoc loc)
+        | Asm (a, b, c, d, e, f, loc) -> Asm (a, b, c, d, e, f, doLoc loc)
 
       (** Change all stmt and instr locs to synthetic, except the first one.
           Expressions/initializers that expand to multiple instructions cannot have intermediate locations referenced. *)
@@ -6893,7 +6893,7 @@ and doStatement (s : A.statement) : chunk =
         currentLoc := loc';
         currentExpLoc := loc'; (* for argument doExp below *)
         let stmts : chunk ref = ref empty in
-	let (tmpls', outs', ins', clobs') =
+	let (tmpls', outs', ins', clobs', gotos') =
 	  match details with
 	  | None ->
 	      let tmpls' =
@@ -6901,8 +6901,8 @@ and doStatement (s : A.statement) : chunk =
 		      let escape = Str.global_replace pattern "%%" in
 		      Util.list_map escape tmpls
 	      in
-	      (tmpls', [], [], [])
-	  | Some { aoutputs = outs; ainputs = ins; aclobbers = clobs } ->
+	      (tmpls', [], [], [], [])
+	  | Some { aoutputs = outs; ainputs = ins; aclobbers = clobs; agotolabels = gotos } ->
               let outs' =
 		Util.list_map
 		  (fun (id, c, e) ->
@@ -6925,10 +6925,10 @@ and doStatement (s : A.statement) : chunk =
 		    (id, c, e'))
 		  ins
               in
-	      (tmpls, outs', ins', clobs)
+	      (tmpls, outs', ins', clobs, gotos)
 	in
         !stmts @@
-        (i2c (Asm(attr', tmpls', outs', ins', clobs', loc')))
+        (i2c (Asm(attr', tmpls', outs', ins', clobs', gotos', loc')))
 
   with e when continueOnError -> begin
     (ignore (E.log "Error in doStatement (%s)\n" (Printexc.to_string e)));

--- a/src/frontc/cabsvisit.ml
+++ b/src/frontc/cabsvisit.ml
@@ -434,13 +434,13 @@ and childrenStatement vis s =
       in
       let details' = match details with
       | None -> details
-      | Some { aoutputs = outl; ainputs = inl; aclobbers = clobs } ->
+      | Some { aoutputs = outl; ainputs = inl; aclobbers = clobs; agotolabels = gotos } ->
 	  let outl' = mapNoCopy childrenIdentStringExp outl in
 	  let inl' = mapNoCopy childrenIdentStringExp inl in
 	  if outl' == outl && inl' == inl then
 	    details
 	  else
-	    Some { aoutputs = outl'; ainputs = inl'; aclobbers = clobs }
+	    Some { aoutputs = outl'; ainputs = inl'; aclobbers = clobs; agotolabels = gotos }
       in
       if details' != details then
         ASM (sl, b, details', l) else s

--- a/src/frontc/frontc.ml
+++ b/src/frontc/frontc.ml
@@ -106,6 +106,8 @@ let args : (string * Arg.spec * string) list =
 exception ParseError of string
 exception CabsOnly
 
+let resetErrors () = E.hadErrors := false
+
 (* parse, and apply patching *)
 let rec parse_to_cabs fname =
 begin

--- a/src/frontc/frontc.mli
+++ b/src/frontc/frontc.mli
@@ -47,6 +47,8 @@ val args: (string * Arg.spec * string) list
 
     (* the main command to parse a file. Return a thunk that can be used to 
        convert the AST to CIL. *)
+val resetErrors: unit -> unit
+
 val parse: string -> (unit -> Cil.file)
 
 val parse_with_cabs: string -> (unit -> Cabs.file * Cil.file)


### PR DESCRIPTION
I am working on a project which utilizes goblint-cil, however I have notice a few short comings, which this attempts to fix:
- The 'asm goto' support should to my understanding be following the gcc spec. (https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html#GotoLabels) 
- ~~The error-state reset, allows resetting when having to parse multiple source files, such that error-states do not propagate.~~

Parts of this were merged as #15.

