### PR TITLE
Add attribute `goblint_cil_nested` to local `varinfo`s that are not declared at top scope

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -565,7 +565,7 @@ let alphaConvertVarAndAddToEnv (addtoenv: bool) (vi: varinfo) : varinfo =
   (* Store all locals in the slocals (in reversed order). We'll reverse them
      and take out the formals at the end of the function *)
   if not vi.vglob then(
-    if List.length !scopes > 1 then
+    if List.length !scopes > 2 then
       newvi.vattr <- Attr("goblint_cil_nested", []) :: newvi.vattr;
     !currentFunctionFDEC.slocals <- newvi :: !currentFunctionFDEC.slocals)
   ;

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -75,6 +75,13 @@ let nocil: int ref = ref (-1)
     *)
 let alwaysGenerateVarDecl = false
 
+(** Add an attribute to all variables which are not declared at the top scope,
+    so tools building on CIL can know which variables were pulled up.
+    Should be disabled when printing CIL code, as compilers will warn about this attribute.
+*)
+let addNestedScopeAttr = ref true
+let body_nest_count = ref 0
+
 (** Indicates whether we're allowed to duplicate small chunks. *)
 let allowDuplication: bool ref = ref true
 
@@ -557,9 +564,11 @@ let alphaConvertVarAndAddToEnv (addtoenv: bool) (vi: varinfo) : varinfo =
   in
   (* Store all locals in the slocals (in reversed order). We'll reverse them
      and take out the formals at the end of the function *)
-  if not vi.vglob then
-    !currentFunctionFDEC.slocals <- newvi :: !currentFunctionFDEC.slocals;
-
+  if not vi.vglob then(
+    if List.length !scopes > 1 then
+      newvi.vattr <- Attr("goblint_cil_nested", []) :: newvi.vattr;
+    !currentFunctionFDEC.slocals <- newvi :: !currentFunctionFDEC.slocals)
+  ;
   (if addtoenv then
     if vi.vglob then
       addGlobalToEnv vi.vname (EnvVar newvi)
@@ -6618,6 +6627,7 @@ and assignInit (lv: lval)
 
   (* Now define the processors for body and statement *)
 and doBody (blk: A.block) : chunk =
+  body_nest_count := !body_nest_count + 1;
   enterScope ();
   (* Rename the labels and add them to the environment *)
   List.iter (fun l -> ignore (genNewLocalLabel l)) blk.blabels;
@@ -6632,6 +6642,7 @@ and doBody (blk: A.block) : chunk =
          empty
          blk.A.bstmts)
   in
+  body_nest_count := !body_nest_count - 1;
   exitScope ();
 
 

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -79,8 +79,7 @@ let alwaysGenerateVarDecl = false
     so tools building on CIL can know which variables were pulled up.
     Should be disabled when printing CIL code, as compilers will warn about this attribute.
 *)
-let addNestedScopeAttr = ref true
-let body_nest_count = ref 0
+let addNestedScopeAttr = ref false
 
 (** Indicates whether we're allowed to duplicate small chunks. *)
 let allowDuplication: bool ref = ref true
@@ -6635,7 +6634,6 @@ and assignInit (lv: lval)
 
   (* Now define the processors for body and statement *)
 and doBody (blk: A.block) : chunk =
-  body_nest_count := !body_nest_count + 1;
   enterScope ();
   (* Rename the labels and add them to the environment *)
   List.iter (fun l -> ignore (genNewLocalLabel l)) blk.blabels;
@@ -6650,7 +6648,6 @@ and doBody (blk: A.block) : chunk =
          empty
          blk.A.bstmts)
   in
-  body_nest_count := !body_nest_count - 1;
   exitScope ();
 
 

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -564,10 +564,18 @@ let alphaConvertVarAndAddToEnv (addtoenv: bool) (vi: varinfo) : varinfo =
   in
   (* Store all locals in the slocals (in reversed order). We'll reverse them
      and take out the formals at the end of the function *)
-  if not vi.vglob then(
-    if List.length !scopes > 2 then
-      newvi.vattr <- Attr("goblint_cil_nested", []) :: newvi.vattr;
-    !currentFunctionFDEC.slocals <- newvi :: !currentFunctionFDEC.slocals)
+  if not vi.vglob then (
+    (if !addNestedScopeAttr then
+      (* two scopes implies top-level scope in the function, one is created for the FUNDEF (includes formals etc),
+         one for the body which is a block *)
+      match !scopes with
+      | _::_::_::_ ->
+        (* i.e.  List.length scopes > 2 *)
+        newvi.vattr <- Attr("goblint_cil_nested", []) :: newvi.vattr
+      | _ -> ()
+    );
+    !currentFunctionFDEC.slocals <- newvi :: !currentFunctionFDEC.slocals
+  )
   ;
   (if addtoenv then
     if vi.vglob then

--- a/src/frontc/cabs2cil.mli
+++ b/src/frontc/cabs2cil.mli
@@ -45,6 +45,12 @@ val forceRLArgEval: bool ref
    -1 to disable *)
 val nocil: int ref
 
+(** Add an attribute to all variables which are not declared at the top scope,
+    so tools building on CIL can know which variables were pulled up.
+    Should be disabled when printing CIL code, as compilers will warn about this attribute.
+*)
+val addNestedScopeAttr: bool ref
+
 (** Indicates whether we're allowed to duplicate small chunks of code. *)
 val allowDuplication: bool ref
 


### PR DESCRIPTION
CIL pulls up all declarations inside a function to the top-level scope of that function. This transformation turns code that has Undefined Behavior into code without any UB, which is of course perfectly ok for a compiler to do, but bad for tools who want to flag this type of UB despite working on the output of CIL.

An example of this is the following snippet:

~~~C
int* ptr;

for(int i =0; i <20; i++) {
    int j =8;
    
    if(i ==0) {
        ptr = &j;
    }
    
    // Will work with most (all) compilers without a hitch, but technically is UB,
    // as ptr points to an object whose lifetime has ended in all but the first iteration 
    *ptr = 5;
}
~~~

After CIL, `j` is pulled to the top scope and there is no more UB.

A rewrite to properly handle scopes seems tedious, and also of questionable value, since it would be a breaking change and would make using CIL more complicated.

This adds an option `addNestedScopeAttr` to `cabs2cil`. When it is enabled, this adds an attribute `goblint_cil_nested` to all `varinfos` for locals that occur inside a nested scope. This way, sound tools can overapproximate for which variables there may be issues.

As the flag is off by default, this should not cause any changes in behavior for other users.

c.f. https://github.com/goblint/analyzer/issues/1199