### PR TITLE
Ignore top level qualifiers in `__builtin_types_compatible_p`

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -4658,7 +4658,8 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
                         prechunk := (fun _ -> empty);
                         piscall := false;
                         let compatible =
-                          try ignore(combineTypes CombineOther t1 t2); true
+                          (* This built-in function ignores top level qualifiers (e.g., const, volatile). *)
+                          try ignore(combineTypes CombineOther (removeOuterQualifierAttributes t1) (removeOuterQualifierAttributes t2)); true
                           with Failure _ -> false
                         in
                         if compatible then

--- a/test/small1/builtin6.c
+++ b/test/small1/builtin6.c
@@ -1,0 +1,10 @@
+
+// Extracted from the git repository.
+// CIL used to crash with "Error: Length of array is negative".
+
+int main() {
+    const int *a;
+    int *ret;
+    sizeof(*(ret)) + (sizeof(char [1 - 2*!(__builtin_types_compatible_p(__typeof__(*((ret))), __typeof__(*((a)))))]) - 1);
+    return 0;
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -548,6 +548,7 @@ addTest("testrun/builtin_choose_expr");
 addTest("testrungcc/builtin_object_size _GNUCC=1 OPTIMIZE=1");
 addTest("testrun/builtin4 ");
 addTest("test/builtin5 ");
+addTest("test/builtin6 ");
 addTest("test/sync-1 _GNUCC=1");
 addTest("test/sync-2 _GNUCC=1");
 addTest("test/sync-3 _GNUCC=1");


### PR DESCRIPTION
When trying to analyze the https://github.com/git/git repository, we encountered the following error:
```
parse-options.c:710: Error: Length of array is negative
Error: There were parsing errors in /home/ubuntu/goblint/new-benchmarks/git/.goblint/preprocessed/parse-options.i
```
This was due to CIL not understanding that in a construct like
```
const int *a;
int *ret;
sizeof(*(ret)) + (sizeof(char [1 - 2*!(__builtin_types_compatible_p(__typeof__(*((ret))), __typeof__(*((a)))))]) - 1);
```
the types are the same.

The built-in function: `int __builtin_types_compatible_p (type1, type2)`  actually [ignores the top level qualifiers (e.g., const, volatile)](https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html), which was not the case in CIL.

This PR adds a test case and fixes the aforementioned issue.