### PR TITLE
Revert "Fix TCompLoop printing being stateful"

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -4624,16 +4624,13 @@ class plainCilPrinterClass =
            self#pAttrs comp.cattr
        else begin
          H.add donecomps comp.ckey (); (* Add it before we do the fields *)
-         let doc = dprintf "TComp(@[%s %s,@?%a,@?%a,@?%a@])"
+         dprintf "TComp(@[%s %s,@?%a,@?%a,@?%a@])"
            (if comp.cstruct then "struct" else "union") comp.cname
            (docList ~sep:(chr ',' ++ break)
               (fun f -> dprintf "%s : %a" f.fname self#pOnlyType f.ftype))
            comp.cfields
            self#pAttrs comp.cattr
            self#pAttrs a
-         in
-         H.remove donecomps comp.ckey; (* Remove it after we do the fields, so printer doesn't have global state *)
-         doc
        end
    | TBuiltin_va_list a ->
        dprintf "TBuiltin_va_list(%a)" self#pAttrs a


### PR DESCRIPTION
This reverts commit eded39ed7af8aa4b1c3b024dc2a8c7f6fe07c488. (c.f. #134)

It causes non-termination of the printers (see https://github.com/goblint/analyzer/issues/1290)