### PR TITLE
Fix first in location synthesizing

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -856,7 +856,7 @@ module BlockChunk =
         in
         (* must mutate stmts in order to not break refs (for gotos) *)
         let rec doStmt ~first s: unit =
-          let doLoc = if first then doLoc else fun x -> x in
+          let doLoc = if first then fun x -> x else doLoc in
           s.skind <- match s.skind with
             | Instr xs -> Instr (doInstrs ~first xs)
             | Return (e, loc) -> Return (e, doLoc loc)


### PR DESCRIPTION
This fixes the `c/weaver/chl-collitem-subst.wvr.c` problem in https://github.com/goblint/analyzer/issues/1356.

Because the logic of making locations synthetic is "Change all stmt and instr locs to synthetic, except the first one." and the `first` flag indicates whether the current statement is first, the logic should be flipped. That is, the first location should not be made synthetic.

It's surprising that this complete logic flip didn't reveal itself from the very beginning of synthetic locations. This could be the reason we couldn't verify so many of our own witnesses even.