### PR TITLE
More efficient `breakString`

### DIFF
--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -70,26 +70,27 @@ type doc =
   | Unmark
 
 (* Break a string at \n *)
-let rec breakString (acc: doc) (str: string) : doc =
-  (* Printf.printf "breaking string %s\n" str; *)
-  match (try Some (String.index str '\n') with Not_found -> None) with
-  | None -> if acc = Nil then Text str else CText (acc, str)
-  | Some r ->
-    (* Printf.printf "r=%d\n" r; *)
-    let len = String.length str in
-    if r > 0 then begin
-      (* Printf.printf "Taking %s\n" (String.sub str 0 r); *)
-      let acc' = Concat(CText (acc, String.sub str 0 r), Line) in
-      if r = len - 1 then (* The last one *)
-        acc'
-      else begin
-        (* Printf.printf "Continuing with %s\n" (String.sub str (r + 1) (len - r - 1)); *)
-        breakString acc'
-          (String.sub str (r + 1) (len - r - 1))
+(* Replaces an earlier implementation that relied on repeatedly calling sub, with one inspired by the standard library *)
+let breakString init s =
+  if s = "" then
+    Nil
+  else
+    let r = ref init in
+    let j = ref (String.length s) in
+    for i = String.length s - 1 downto 0 do
+      let text = Text (String.sub s (i + 1) (!j - i - 1)) in
+      if String.unsafe_get s i = '\n' then begin
+        if !r = Nil then
+          r := Concat(Line, text)
+        else
+          r := Concat(Line, Concat(text, !r));
+        j := i
       end
-    end else (* The first is a newline *)
-      breakString (Concat(acc, Line))
-        (String.sub str (r + 1) (len - r - 1))
+    done;
+    if !r = Nil then
+      Text (String.sub s 0 !j)
+    else
+      Concat(Text (String.sub s 0 !j), Concat(Line, !r))
 
 
 let nil           = Nil
@@ -591,7 +592,7 @@ let print_with_state ~width f =
     topAlignAbsCol := old_topAlignAbsCol;
     breakAllMode := old_breakAllMode
   in
-  
+
   match f () with
   | r ->
     finally ();

--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -73,25 +73,25 @@ type doc =
 (* Replaces an earlier implementation that relied on repeatedly calling sub, with one inspired by the standard library *)
 let breakString init s =
   if s = "" then
-    Nil
+    init
   else
     let r = ref init in
     let j = ref (String.length s) in
     for i = String.length s - 1 downto 0 do
-      let text = Text (String.sub s (i + 1) (!j - i - 1)) in
       if String.unsafe_get s i = '\n' then begin
-        if !r = Nil then
-          r := Concat(Line, text)
+        let text = (String.sub s (i + 1) (!j - i - 1)) in
+        (if !r = Nil then
+          r := CText(Line, text)
         else
-          r := Concat(Line, Concat(text, !r));
+          r := Concat(Line, CText(!r, text)));
         j := i
       end
     done;
-    let text = Text (String.sub s 0 !j) in
+    let text = String.sub s 0 !j in
     if !r = Nil then
-      text
+      Text text
     else
-      Concat(text, Concat(Line, !r))
+      CText(!r, text)
 
 
 let nil           = Nil

--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -87,10 +87,11 @@ let breakString init s =
         j := i
       end
     done;
+    let text = Text (String.sub s 0 !j) in
     if !r = Nil then
-      Text (String.sub s 0 !j)
+      text
     else
-      Concat(Text (String.sub s 0 !j), Concat(Line, !r))
+      Concat(text, Concat(Line, !r))
 
 
 let nil           = Nil

--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -71,19 +71,19 @@ type doc =
 
 (* Break a string at \n *)
 (* Replaces an earlier implementation that relied on repeatedly calling sub, with one inspired by the standard library *)
-let breakString init s =
+let breakString s =
   if s = "" then
-    init
+    Nil
   else
-    let r = ref init in
+    let r = ref Nil in
     let j = ref (String.length s) in
     for i = String.length s - 1 downto 0 do
       if String.unsafe_get s i = '\n' then begin
         let text = (String.sub s (i + 1) (!j - i - 1)) in
         (if !r = Nil then
-          r := CText(Line, text)
+          r := Concat(Line,Text text)
         else
-          r := Concat(Line, CText(!r, text)));
+          r := Concat(Line, Concat(Text text, !r)));
         j := i
       end
     done;
@@ -91,11 +91,11 @@ let breakString init s =
     if !r = Nil then
       Text text
     else
-      CText(!r, text)
+      Concat(Text text,!r)
 
 
 let nil           = Nil
-let text s        = breakString nil s
+let text s        = breakString s
 let num  i        = text (string_of_int i)
 let num64 i       = text (Int64.to_string i)
 let real f        = text (string_of_float f)
@@ -707,7 +707,7 @@ let gprintf (finish : doc -> 'b)
                   else
                     s
               in
-              collect (breakString acc str) (succ j))
+              collect (Concat(acc, breakString str)) (succ j))
         | 'c' ->
             Obj.magic(fun c ->
               collect (dctext1 acc (String.make 1 c)) (succ j))

--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -79,11 +79,11 @@ let breakString s =
     let j = ref (String.length s) in
     for i = String.length s - 1 downto 0 do
       if String.unsafe_get s i = '\n' then begin
-        let text = (String.sub s (i + 1) (!j - i - 1)) in
+        let text = Text (String.sub s (i + 1) (!j - i - 1)) in
         (if !r = Nil then
-          r := Concat(Line,Text text)
+          r := Concat(Line, text)
         else
-          r := Concat(Line, Concat(Text text, !r)));
+          r := Concat(Line, Concat(text, !r)));
         j := i
       end
     done;
@@ -91,7 +91,7 @@ let breakString s =
     if !r = Nil then
       Text text
     else
-      Concat(Text text,!r)
+      Concat(Text text, !r)
 
 
 let nil           = Nil

--- a/src/ocamlutil/pretty.ml
+++ b/src/ocamlutil/pretty.ml
@@ -72,26 +72,30 @@ type doc =
 (* Break a string at \n *)
 (* Replaces an earlier implementation that relied on repeatedly calling sub, with one inspired by the standard library *)
 let breakString s =
-  if s = "" then
-    Nil
-  else
-    let r = ref Nil in
-    let j = ref (String.length s) in
-    for i = String.length s - 1 downto 0 do
-      if String.unsafe_get s i = '\n' then begin
-        let text = Text (String.sub s (i + 1) (!j - i - 1)) in
-        (if !r = Nil then
-          r := Concat(Line, text)
+  let r = ref Nil in
+  let j = ref (String.length s) in
+  for i = String.length s - 1 downto 0 do
+    if String.unsafe_get s i = '\n' then begin
+      let text = String.sub s (i + 1) (!j - i - 1) in
+      (if text = "" then
+        if !r = Nil then
+          r := Line
         else
-          r := Concat(Line, Concat(text, !r)));
-        j := i
-      end
-    done;
-    let text = String.sub s 0 !j in
-    if !r = Nil then
-      Text text
-    else
-      Concat(Text text, !r)
+          r := Concat(Line, !r)
+      else
+        if !r = Nil then
+          r := Concat(Line, Text text)
+        else
+          r := Concat(Line, Concat(Text text, !r))
+      );
+      j := i
+    end
+  done;
+  let text = String.sub s 0 !j in
+  if text = "" then
+    !r
+  else
+    Concat(Text text, !r)
 
 
 let nil           = Nil


### PR DESCRIPTION
Closes #169.

See also https://github.com/goblint/analyzer/issues/1513 that also has some runtime comparisons.