### PR TITLE
Fix pretty-printing of enumerations

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -4017,7 +4017,7 @@ class defaultCilPrinterClass : cilPrinter = object (self)
                 (fun (n, attrs, i, loc) ->
                   text n
                     ++ self#pAttrs () attrs
-                    ++ text (n ^ " = ")
+                    ++ text " = "
                     ++ self#pExp () i)
                 () enum.eitems)
           ++ unalign ++ line ++ text "} "


### PR DESCRIPTION
Before this change enumeration items were duplicated by the default pretty-printer.

Here's a way to check the behavior of the pretty-printer. With `test.ml` and `x.c` as follows:
```ocaml
#use "topfind";;
#require "goblint-cil";;
GoblintCil.dumpFile GoblintCil.defaultCilPrinter Stdlib.stdout ""
  (GoblintCil.Frontc.parse "x.c" ());;
```
```c
enum e { A, B };
```

Before this PR, test command `ocaml ./test.ml | head` resulted in
```c
/* Generated by Goblint-CIL v. %%VERSION_NUM%% */
/* print_CIL_Input is false */

#line 1 "x.c"
enum e {
    AA = 0,
    BB = 1
} ;
```