### PR TITLE
Use `gnu11` standard for most tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -386,11 +386,11 @@ MYSAFECC := $(CILLY)
 comb: $(TESTDIR)/small2/comb1.c $(TESTDIR)/small2/comb2.c
 	rm -f $(TESTDIR)/small2/comb.exe
 	cd $(TESTDIR)/small2; \
-	  $(MYSAFECC) -fcommon comb1.c $(CONLY) $(OBJOUT) comb1.o; \
-	  $(MYSAFECC) -fcommon comb2.c $(CONLY) $(OBJOUT) comb2.o; \
-	  $(MYSAFECC) -fcommon comb3.c $(CONLY) $(OBJOUT) comb3.o; \
-	  $(MYSAFECC) -fcommon comb4.c $(CONLY) $(OBJOUT) comb4.o; \
-          $(MYSAFECC) -fcommon comb1.o comb2.o comb3.o comb4.o $(EXEOUT)comb.exe
+	  $(MYSAFECC) -std=gnu11 -fcommon comb1.c $(CONLY) $(OBJOUT) comb1.o; \
+	  $(MYSAFECC) -std=gnu11 -fcommon comb2.c $(CONLY) $(OBJOUT) comb2.o; \
+	  $(MYSAFECC) -std=gnu11 -fcommon comb3.c $(CONLY) $(OBJOUT) comb3.o; \
+	  $(MYSAFECC) -std=gnu11 -fcommon comb4.c $(CONLY) $(OBJOUT) comb4.o; \
+          $(MYSAFECC) -std=gnu11 -fcommon comb1.o comb2.o comb3.o comb4.o $(EXEOUT)comb.exe
 	$(TESTDIR)/small2/comb.exe
 
 #call cilly on a .c file, a .i file, a .s file, and a .o file.
@@ -398,10 +398,10 @@ comb: $(TESTDIR)/small2/comb1.c $(TESTDIR)/small2/comb2.c
 mixedcomb: $(TESTDIR)/small2/comb1.c $(TESTDIR)/small2/comb2.c
 	rm -f $(TESTDIR)/small2/comb.exe
 	cd $(TESTDIR)/small2; \
-	  gcc -fcommon -E -o comb2.i comb2.c; \
-	  gcc -fcommon -S -o comb3.s comb3.c; \
-	  gcc -fcommon -c -o comb4.o comb4.c; \
-	  $(MYSAFECC) -fcommon  comb1.c comb2.i comb3.s comb4.o $(EXEOUT)comb.exe
+	  gcc -std=gnu11 -fcommon -E -o comb2.i comb2.c; \
+	  gcc -std=gnu11 -fcommon -S -o comb3.s comb3.c; \
+	  gcc -std=gnu11 -fcommon -c -o comb4.o comb4.c; \
+	  $(MYSAFECC) -std=gnu11 -fcommon  comb1.c comb2.i comb3.s comb4.o $(EXEOUT)comb.exe
 	$(TESTDIR)/small2/comb.exe
 
 # sm: another merger test

--- a/test/Makefile
+++ b/test/Makefile
@@ -130,6 +130,9 @@ endif
 # Disable GCC 14 new warnings as errors because some tests contain them
 CFLAGS += -Wno-error=implicit-int -Wno-error=implicit-function-declaration -Wno-error=int-conversion -Wno-error=incompatible-pointer-types
 
+# TODO: Force gnu11 because we're not ready for c23 yet
+CFLAGS += -std=gnu11 
+
 # sm: this will make gcc warnings into errors; it's almost never
 # what we want, but for a particular testcase (combine_copyptrs)
 # I need it to show the difference between something which works
@@ -176,7 +179,7 @@ SMALL1 := $(TESTDIR)/small1
 
 test/% : $(SMALL1)/%.c
 	cd $(SMALL1); $(CILLY) --nomerge --commPrintLn \
-	       $(CONLY) -std=gnu90 $(CFLAGS) $(ASMONLY)$*.s $*.c
+	       $(CONLY) $(CFLAGS) -std=gnu90 $(ASMONLY)$*.s $*.c
 	echo SUCCESS
 
 testobj/% : $(SMALL1)/%.c


### PR DESCRIPTION
Closes #188.

Actually also fixes #189, but it already has a proper fix as well.