### PR TITLE
Separate `machdep-config.h` for each architecture

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -17,9 +17,17 @@
  (action (run ./machdepConfigure.exe)))
 
 (rule
+ (target machdep32-config.h)
+ (action (run ./machdepConfigure.exe -m 32)))
+
+(rule
+ (target machdep64-config.h)
+ (action (run ./machdepConfigure.exe -m 64)))
+
+(rule
  (deps machdep-config.h machdep-ml.c)
  (target machdep-ml.exe)
- (action (run %{read-lines:../bin/real-gcc} -D_GNUCC machdep-ml.c -o %{target})))
+ (action (run %{read-lines:../bin/real-gcc} -D_GNUCC -include machdep-config.h machdep-ml.c -o %{target})))
 
 (executable
  (name machdepArchConfigure)
@@ -27,12 +35,12 @@
  (libraries dune-configurator))
 
 (rule
- (deps machdep-config.h machdep-ml.c)
+ (deps machdep32-config.h machdep-ml.c)
  (target machdep32)
  (action (with-stdout-to %{target} (run ./machdepArchConfigure.exe --real-gcc %{read-lines:../bin/real-gcc} -m 32))))
 
 (rule
- (deps machdep-config.h machdep-ml.c)
+ (deps machdep64-config.h machdep-ml.c)
  (target machdep64)
  (action (with-stdout-to %{target} (run ./machdepArchConfigure.exe --real-gcc %{read-lines:../bin/real-gcc} -m 64))))
 
@@ -44,13 +52,13 @@
 
 ; for Cilly.pm
 (rule
- (deps machdep-config.h machdep-ml.c)
+ (deps machdep32-config.h machdep-ml.c)
  (target gcc32model)
  (action (with-stdout-to %{target} (run ./modelConfigure.exe --real-gcc %{read-lines:../bin/real-gcc} -m 32))))
 
 ; for Cilly.pm
 (rule
- (deps machdep-config.h machdep-ml.c)
+ (deps machdep64-config.h machdep-ml.c)
  (target gcc64model)
  (action (with-stdout-to %{target} (run ./modelConfigure.exe --real-gcc %{read-lines:../bin/real-gcc} -m 64))))
 

--- a/src/machdep-ml.c
+++ b/src/machdep-ml.c
@@ -35,7 +35,8 @@
 
  */
 
-#include "machdep-config.h"
+// Correct config header is now included from command line using -include.
+// #include "machdep-config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/src/machdepArchConfigure.ml
+++ b/src/machdepArchConfigure.ml
@@ -10,7 +10,7 @@ let () =
   in
   C.main ~name:"model" ~args (fun c ->
       let exe = "./machdep" ^ !m ^ "-ml.exe" in
-      let {C.Process.exit_code; stdout; stderr} = C.Process.run c !real_gcc ["-D_GNUCC"; "-m" ^ !m; "machdep-ml.c"; "-o"; exe] in
+      let {C.Process.exit_code; stdout; stderr} = C.Process.run c !real_gcc ["-D_GNUCC"; "-include"; "machdep" ^ !m ^ "-config.h"; "-m" ^ !m; "machdep-ml.c"; "-o"; exe] in
       if exit_code = 0 then (
         let {C.Process.stdout; stderr; exit_code} = C.Process.run c exe [] in
         assert (exit_code = 0);

--- a/src/machdepConfigure.ml
+++ b/src/machdepConfigure.ml
@@ -2,6 +2,10 @@ module C = Configurator.V1
 
 let c_flags = ref []
 
+let base_code = {|
+int main() { return 0; }
+|}
+
 let has_header_code f =
   Format.sprintf {|
 #include <%s>
@@ -89,26 +93,31 @@ let () =
     ]
   in
   C.main ~name:"machdep" ~args (fun c ->
-      let have_builtin_va_list = C.c_test c ~c_flags:!c_flags builtin_va_list_code in
-      let thread_is_keyword = not @@ C.c_test c ~c_flags:!c_flags thread_is_keyword_code in
-      let underscore_name = C.c_test c ~c_flags:!c_flags underscore_name_code in
-      let have_float16 = C.c_test c ~c_flags:!c_flags have_float16_code in
+      if C.c_test c ~c_flags:!c_flags base_code then (
+        let have_builtin_va_list = C.c_test c ~c_flags:!c_flags builtin_va_list_code in
+        let thread_is_keyword = not @@ C.c_test c ~c_flags:!c_flags thread_is_keyword_code in
+        let underscore_name = C.c_test c ~c_flags:!c_flags underscore_name_code in
+        let have_float16 = C.c_test c ~c_flags:!c_flags have_float16_code in
 
-      C.C_define.gen_header_file c ~fname:!fname [
-        ("HAVE_STDLIB_H", Switch (has_header c "stdlib.h"));
-        ("HAVE_WCHAR_H", Switch (has_header c "wchar.h"));
-        ("HAVE_STDBOOL_H", Switch (has_header c "stdbool.h"));
-        ("HAVE_INTTYPES_H", Switch (has_header c "inttypes.h"));
-        ("HAVE_STDINT_H", Switch (has_header c "stdint.h"));
+        C.C_define.gen_header_file c ~fname:!fname [
+          ("HAVE_STDLIB_H", Switch (has_header c "stdlib.h"));
+          ("HAVE_WCHAR_H", Switch (has_header c "wchar.h"));
+          ("HAVE_STDBOOL_H", Switch (has_header c "stdbool.h"));
+          ("HAVE_INTTYPES_H", Switch (has_header c "inttypes.h"));
+          ("HAVE_STDINT_H", Switch (has_header c "stdint.h"));
 
-        ("HAVE_BUILTIN_VA_LIST_DEF", Switch have_builtin_va_list);
-        ("THREAD_IS_KEYWORD_DEF", Switch thread_is_keyword);
-        ("UNDERSCORE_NAME_DEF", Switch underscore_name);
-        ("HAVE_FLOAT16_DEF", Switch have_float16);
+          ("HAVE_BUILTIN_VA_LIST_DEF", Switch have_builtin_va_list);
+          ("THREAD_IS_KEYWORD_DEF", Switch thread_is_keyword);
+          ("UNDERSCORE_NAME_DEF", Switch underscore_name);
+          ("HAVE_FLOAT16_DEF", Switch have_float16);
 
-        ("TYPE_SIZE_T", String (cil_check_integer_type c "size_t"));
-        ("TYPE_WCHAR_T", String (cil_check_integer_type c "wchar_t"));
-        ("TYPE_CHAR16_T", String (cil_check_integer_type c "char16_t"));
-        ("TYPE_CHAR32_T", String (cil_check_integer_type c "char32_t"));
-      ]
+          ("TYPE_SIZE_T", String (cil_check_integer_type c "size_t"));
+          ("TYPE_WCHAR_T", String (cil_check_integer_type c "wchar_t"));
+          ("TYPE_CHAR16_T", String (cil_check_integer_type c "char16_t"));
+          ("TYPE_CHAR32_T", String (cil_check_integer_type c "char32_t"));
+        ]
+      )
+      else (
+        C.C_define.gen_header_file c ~fname:!fname []
+      )
     )

--- a/src/machdepConfigure.ml
+++ b/src/machdepConfigure.ml
@@ -1,5 +1,7 @@
 module C = Configurator.V1
 
+let c_flags = ref []
+
 let has_header_code f =
   Format.sprintf {|
 #include <%s>
@@ -7,7 +9,7 @@ int main() { return 0; } // Just so that dune-configurator linking works
   |} f
 
 let has_header c f =
-  C.c_test c (has_header_code f)
+  C.c_test c ~c_flags:!c_flags (has_header_code f)
 
 let builtin_va_list_code = {|
 int
@@ -59,7 +61,7 @@ int main() { return 0; } // Just so that dune-configurator linking works
 exception FoundType of string
 
 let cil_check_integer_type_type c t1 t2 =
-  if C.c_test c (cil_check_integer_type_type_code t1 t2) then
+  if C.c_test c ~c_flags:!c_flags (cil_check_integer_type_type_code t1 t2) then
     raise (FoundType t2)
 
 let cil_check_integer_type_signs c t1 t2 =
@@ -78,13 +80,21 @@ let cil_check_integer_type c t1 =
     t2
 
 let () =
-  C.main ~name:"machdep" (fun c ->
-      let have_builtin_va_list = C.c_test c builtin_va_list_code in
-      let thread_is_keyword = not @@ C.c_test c thread_is_keyword_code in
-      let underscore_name = C.c_test c underscore_name_code in
-      let have_float16 = C.c_test c have_float16_code in
+  let fname = ref "machdep-config.h" in
+  let args = Arg.[
+      ("-m", String (fun s ->
+          c_flags := ("-m" ^ s) :: !c_flags;
+          fname := "machdep" ^ s ^ "-config.h";
+        ), "");
+    ]
+  in
+  C.main ~name:"machdep" ~args (fun c ->
+      let have_builtin_va_list = C.c_test c ~c_flags:!c_flags builtin_va_list_code in
+      let thread_is_keyword = not @@ C.c_test c ~c_flags:!c_flags thread_is_keyword_code in
+      let underscore_name = C.c_test c ~c_flags:!c_flags underscore_name_code in
+      let have_float16 = C.c_test c ~c_flags:!c_flags have_float16_code in
 
-      C.C_define.gen_header_file c ~fname:"machdep-config.h" [
+      C.C_define.gen_header_file c ~fname:!fname [
         ("HAVE_STDLIB_H", Switch (has_header c "stdlib.h"));
         ("HAVE_WCHAR_H", Switch (has_header c "wchar.h"));
         ("HAVE_STDBOOL_H", Switch (has_header c "stdbool.h"));

--- a/src/modelConfigure.ml
+++ b/src/modelConfigure.ml
@@ -10,7 +10,7 @@ let () =
   in
   C.main ~name:"model" ~args (fun c ->
       let exe = "./machdep-ml" ^ !m ^ ".exe" in
-      let {C.Process.exit_code; stdout; stderr} = C.Process.run c !real_gcc ["-D_GNUCC"; "-m" ^ !m; "machdep-ml.c"; "-o"; exe] in
+      let {C.Process.exit_code; stdout; stderr} = C.Process.run c !real_gcc ["-D_GNUCC"; "-include"; "machdep" ^ !m ^ "-config.h"; "-m" ^ !m; "machdep-ml.c"; "-o"; exe] in
       if exit_code = 0 then (
         let {C.Process.stdout; stderr; exit_code} = C.Process.run c exe ["--env"] in
         assert (exit_code = 0);


### PR DESCRIPTION
This fixes a regression from #193 after which Goblint started erroring on 32-bit SV-COMP tasks with
```
[Error][Unsound] Machine definition not available for selected architecture
```
The problem is that `_Float16` is available on 64-bit, but not 32-bit, so separate headers are needed. Otherwise the compilation of 32-bit machdep generation fails.

The headers should've been separate from the beginning. It's surprising that nothing broke before.