### PR TITLE
Add missing integer promotion to unary plus

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -4020,8 +4020,17 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
         else
           E.s (error "Unary ~ on a non-integral type")
 
-    | A.UNARY(A.PLUS, e) -> doExp asconst e what
-
+    | A.UNARY(A.PLUS, e) ->
+        let (se, e', t) = doExp asconst e (AExp None) in
+        if isIntegralType t then
+          let tres = integralPromotion t in
+          let e'' = makeCastT ~e:e' ~oldt:t ~newt:tres in
+          finishExp se e'' tres
+        else
+          if isArithmeticType t then
+            finishExp se e' t
+          else
+            E.s (error "Unary + on a non-arithmetic type")
 
     | A.UNARY(A.ADDROF, e) -> begin
         match e with

--- a/test/small1/unary-plus-promotion.c
+++ b/test/small1/unary-plus-promotion.c
@@ -1,0 +1,13 @@
+#include "testharness.h"
+#include <stdlib.h>
+
+int main() {
+  char c;
+  size_t csize = sizeof(c);
+  size_t pluscsize = sizeof(+c);
+  if (csize != sizeof(char))
+    E(1);
+  if (pluscsize != sizeof(int))
+    E(2);
+  SUCCESS;
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -323,6 +323,7 @@ addTest("test/li");
 addTest("test_i/lineno");
 addTest("test/list");
 addTest("testrun/localinit ");
+addTest("testrun/unary-plus-promotion");
 
 addTest('testrun/longBlock', '');
 addTest("testrun/perror");


### PR DESCRIPTION
After https://github.com/goblint/analyzer/pull/1905 I was wondering about the unary plus and looked up the standard to see what (if anything) it's supposed to do. Turns out it performs integer promotions, which CIL wasn't doing. Instead, CIL just treated it as no-op, which is true on the execution level, but not the type level.

Conflicts with #199.