### PR TITLE
Add multiplication support to attribute parameter evaluation

### DIFF
--- a/src/cil.ml
+++ b/src/cil.ml
@@ -2358,19 +2358,13 @@ and intOfAttrparam (a:attrparam) : int option =
     match a with
       AInt(n) -> n
     | ABinOp(Shiftlt, a1, a2) -> (doit a1) lsl (doit a2)
+    | ABinOp(Mult, a1, a2) -> (doit a1) * (doit a2)
     | ABinOp(Div, a1, a2) -> (doit a1) / (doit a2)
     | ASizeOf(t) ->
         let bs = bitsSizeOf t in
         bs / 8
     | AAlignOf(t) ->
         alignOf_int t
-    | ABinOp (op, lhs, rhs) -> begin
-      let lhs_val = doit lhs in
-      let rhs_val = doit rhs in
-      match op with
-        Mult -> lhs_val * rhs_val
-      | _ -> raise (SizeOfError ("", voidType))
-      end
     | _ -> raise (SizeOfError ("", voidType))
   in
   (* Use ignoreAlignmentAttrs here to prevent stack overflow if a buggy

--- a/src/cil.ml
+++ b/src/cil.ml
@@ -2364,6 +2364,13 @@ and intOfAttrparam (a:attrparam) : int option =
         bs / 8
     | AAlignOf(t) ->
         alignOf_int t
+    | ABinOp (op, lhs, rhs) -> begin
+      let lhs_val = doit lhs in
+      let rhs_val = doit rhs in
+      match op with
+        Mult -> lhs_val * rhs_val
+      | _ -> raise (SizeOfError ("", voidType))
+      end
     | _ -> raise (SizeOfError ("", voidType))
   in
   (* Use ignoreAlignmentAttrs here to prevent stack overflow if a buggy

--- a/test/small1/attr-multiplication.c
+++ b/test/small1/attr-multiplication.c
@@ -1,0 +1,8 @@
+struct S1 {
+    char a;
+} __attribute__((aligned(sizeof(short) * sizeof(int))));
+
+
+struct S2 {
+    int x: __builtin_choose_expr(__alignof__ (struct S1) == sizeof(short) * sizeof(int), 1, -1);
+} s2;

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -225,6 +225,7 @@ addTest("test/attr10 _GNUCC=1");
 addTest("test/attr11 _GNUCC=1");
 addTest("test/attr12 _GNUCC=1");
 addTest("test/attr13 _GNUCC=1");
+addTest("test/attr-multiplication");
 # addTest("test/attr-assign"); # TODO: only on OSX, Linux GCC errors on introduced
 # addTest("test/attr-enumerator"); # TODO: only on OSX, Linux GCC errors on introduced
 addTest("testrun/packed _GNUCC=1 WARNINGS_ARE_ERRORS=1");


### PR DESCRIPTION
This feature is necessary for Linux kernel module analysis.