### PR TITLE
Implement `__builtin_clzll` builtin

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -4755,20 +4755,14 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
                 else if fv.vname = "__builtin_clzll" then
                   begin
                   (* Constant-fold the argument and see if it is a constant *)
-                    let rec countLeadingZeros (arg: cilint) pos count =
-                      if is_zero_cilint (logand_cilint (shift_right_cilint arg pos) one_cilint) then
-                        match pos with
-                          0 -> count + 1
-                        | _ -> countLeadingZeros arg (pos - 1) (count + 1)
-                      else
-                        count
+                    let countLeadingZeros (arg: cilint) pos = pos - Z.numbits arg
                     in
                     match !pargs with
                       [ arg ] -> begin
                         match constFold true arg with
                           (Const CInt (arg, kind, _)) ->
                             piscall := false;
-                            pres := integer (countLeadingZeros arg 63 0);
+                            pres := integer (countLeadingZeros arg 64);
                             prestype := intType
                         | _ -> ()
                       end

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -4752,6 +4752,28 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
                           prestype := intType
                   | _ -> ignore (warn "Invalid call to builtin_types_compatible_p");
                 end
+                else if fv.vname = "__builtin_clzll" then
+                  begin
+                  (* Constant-fold the argument and see if it is a constant *)
+                    let rec countLeadingZeros (arg: cilint) pos count =
+                      if is_zero_cilint (logand_cilint (shift_right_cilint arg pos) one_cilint) then
+                        match pos with
+                          0 -> count + 1
+                        | _ -> countLeadingZeros arg (pos - 1) (count + 1)
+                      else
+                        count
+                    in
+                    match !pargs with
+                      [ arg ] -> begin
+                        match constFold true arg with
+                          (Const CInt (arg, kind, _)) ->
+                            piscall := false;
+                            pres := integer (countLeadingZeros arg 63 0);
+                            prestype := intType
+                        | _ -> ()
+                      end
+                    | _ -> ignore (warn "Invalid call to __builtin_clzll");
+                  end
             end
           | _ -> ()
         );

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -4752,7 +4752,7 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
                           prestype := intType
                   | _ -> ignore (warn "Invalid call to builtin_types_compatible_p");
                 end
-                else if fv.vname = "__builtin_clzll" then
+                else if fv.vname = "__builtin_clzll" && asconst && isEmpty (!prechunk ()) then
                   begin
                   (* Constant-fold the argument and see if it is a constant *)
                     let countLeadingZeros (arg: cilint) pos = pos - Z.numbits arg

--- a/test/small1/builtin_clzll.c
+++ b/test/small1/builtin_clzll.c
@@ -1,0 +1,9 @@
+struct S1 {
+    int x : __builtin_choose_expr(__builtin_clzll(0ull) == 64, 1, -1),
+          : __builtin_choose_expr(__builtin_clzll(~0ull) == 0, 1, -1),
+          : __builtin_choose_expr(__builtin_clzll(1) == 63, 1, -1),
+          : __builtin_choose_expr(__builtin_clzll(2) == 62, 1, -1),
+          : __builtin_choose_expr(__builtin_clzll(4) == 61, 1, -1),
+          : __builtin_choose_expr(__builtin_clzll(1024) == 53, 1, -1),
+          : __builtin_choose_expr(__builtin_clzll(1024 * 1024) == 43, 1, -1);
+} s1;

--- a/test/small1/builtin_clzll.c
+++ b/test/small1/builtin_clzll.c
@@ -1,9 +1,11 @@
 struct S1 {
-    int x : __builtin_choose_expr(__builtin_clzll(0ull) == 64, 1, -1),
-          : __builtin_choose_expr(__builtin_clzll(~0ull) == 0, 1, -1),
-          : __builtin_choose_expr(__builtin_clzll(1) == 63, 1, -1),
+    int x : __builtin_choose_expr(__builtin_clzll(1) == 63, 1, -1),
           : __builtin_choose_expr(__builtin_clzll(2) == 62, 1, -1),
           : __builtin_choose_expr(__builtin_clzll(4) == 61, 1, -1),
           : __builtin_choose_expr(__builtin_clzll(1024) == 53, 1, -1),
           : __builtin_choose_expr(__builtin_clzll(1024 * 1024) == 43, 1, -1);
-} s1;
+} s1 = {0};
+
+int main() {
+    return 0;
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -555,7 +555,7 @@ addTest("testrungcc/builtin_object_size _GNUCC=1 OPTIMIZE=1");
 addTest("testrun/builtin4 ");
 addTest("test/builtin5 ");
 addTest("test/builtin6 ");
-addTest("test/builtin_clzll");
+addTest("testrun/builtin_clzll ");
 addTest("test/sync-1 _GNUCC=1");
 addTest("test/sync-2 _GNUCC=1");
 addTest("test/sync-3 _GNUCC=1");

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -555,6 +555,7 @@ addTest("testrungcc/builtin_object_size _GNUCC=1 OPTIMIZE=1");
 addTest("testrun/builtin4 ");
 addTest("test/builtin5 ");
 addTest("test/builtin6 ");
+addTest("test/builtin_clzll");
 addTest("test/sync-1 _GNUCC=1");
 addTest("test/sync-2 _GNUCC=1");
 addTest("test/sync-3 _GNUCC=1");


### PR DESCRIPTION
This feature is necessary for Linux kernel module analysis.