### PR TITLE
Permit impure expressions in `__auto_type`

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -5876,9 +5876,8 @@ and createAutoLocal ((((n, ndt, a, cloc) : A.name), (inite: A.init_expression)) 
   else
     match inite with
     | SINGLE_INIT exp ->
-      (match doExp true exp (AExp None) with
-      | (_, exp, _) ->
-        let t = Cil.typeOf exp in
+      (match doExp false exp (AExp None) with (* doExp with AExp handles array and function types (AType would not!) *)
+      | (_, _, t) ->
         let specs = t,NoStorage,false,[] in
         createLocal specs name
       )

--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -5876,12 +5876,11 @@ and createAutoLocal ((((n, ndt, a, cloc) : A.name), (inite: A.init_expression)) 
   else
     match inite with
     | SINGLE_INIT exp ->
-      (match doPureExp exp with
-      | Some exp ->
+      (match doExp true exp (AExp None) with
+      | (_, exp, _) ->
         let t = Cil.typeOf exp in
         let specs = t,NoStorage,false,[] in
         createLocal specs name
-      | None -> E.s (error "__auto_type but init not pure")
       )
     | _ -> E.s (error "__auto_type but not SINGLE_INIT")
 (* Must catch the Static local variables. Make them global *)

--- a/test/small1/auto_type1.c
+++ b/test/small1/auto_type1.c
@@ -1,0 +1,14 @@
+struct dummmy {
+    char arr[0x0bad];
+};
+
+extern volatile struct dummmy side_effect1;
+struct dummmy side_effect2(struct dummmy);
+
+void *fn() {
+    __auto_type x = side_effect2(side_effect1);
+    static struct S1 {
+        int a : __builtin_choose_expr(sizeof(x) == 0x0bad, 1, -1);
+    } s1 = {0};
+    return &s1;
+}

--- a/test/small1/auto_type2.c
+++ b/test/small1/auto_type2.c
@@ -1,0 +1,26 @@
+#define ASSERT_TYPE3(_expr, _type, _c) \
+    struct assertType##_c { \
+        int x: _Generic(_expr, _type : 1, default : -1); \
+    } assertValue##_c = {0}
+#define ASSERT_TYPE2(_expr, _type, _c) ASSERT_TYPE3(_expr, _type, _c)
+#define ASSERT_TYPE(_expr, _type) ASSERT_TYPE2(_expr, _type, __COUNTER__)
+
+void fn1(const int arg[128]) {
+    const int local[128] = {0};
+
+    typeof(arg) ptr4;
+    typeof(local) ptr5 = {0};
+    __auto_type ptr6 = arg;
+    __auto_type ptr7 = local;
+
+    ASSERT_TYPE(&ptr4, const int **);
+    ASSERT_TYPE(&ptr5, const int (*)[128]);
+    ASSERT_TYPE(&ptr6, const int **);
+    ASSERT_TYPE(&ptr7, const int **);
+}
+
+int main() {
+    int arg[128] = {0};
+    fn1(arg);
+    return 0;
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -536,6 +536,7 @@ addTest("testrun/min ");
 
 
 addTest("testrun/typeof1 ");
+addTest("test/auto_type1");
 addTest("testrun/semicolon _GNUCC=1");
 
 addTest("merge-ar ");

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -537,6 +537,7 @@ addTest("testrun/min ");
 
 addTest("testrun/typeof1 ");
 addTest("test/auto_type1");
+addTest("testrun/auto_type2");
 addTest("testrun/semicolon _GNUCC=1");
 
 addTest("merge-ar ");


### PR DESCRIPTION
This feature is necessary for Linux kernel module analysis.