### PR TITLE
Publish docs using standard GitHub Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,8 +45,7 @@ jobs:
           path: _build/default/doc/html/cil/
 
   deploy:
-    # TODO: uncomment
-    # if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
     needs: build
 
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,52 +1,64 @@
 name: docs
+
 on:
   push:
+  pull_request:
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+  
 jobs:
   build:
-    concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
     runs-on: ubuntu-latest
+    
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # fetch all history such that subst gives nice version
 
-      - name: Setup OCaml ${{ matrix.ocaml-version }}
+      - name: Set up OCaml 4.14.x
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 4.13.1
+          ocaml-compiler: 4.14.x
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
 
       - run: opam pin add goblint-cil.dev . --no-action
       - run: opam depext goblint-cil --yes
       - run: opam depext goblint-cil --yes --with-doc
       - run: opam install . --deps-only --with-doc
-      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+      
+      - name: Build docs
         run: |
           opam exec -- dune subst
           opam exec -- dune build @heveadoc
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          name: doc-html
-          path: _build/default/doc/html/cil
+          path: _build/default/doc/html/cil/
 
   deploy:
-    if: github.ref == 'refs/heads/develop'
+    # TODO: uncomment
+    # if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
     needs: build
+
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    
+    concurrency:
+      group: "pages"
+      cancel-in-progress: true
+
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v3 # check out git repo to make deploy action happy
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: doc-html
-          path: _build/default/doc/html/cil
-
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: _build/default/doc/html/cil
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This avoids cluttering the git history with commits to `gh-pages` by the non-standard action.