### PR TITLE
Fold constant conditional expressions, even without `lowerConstants`

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -5239,7 +5239,7 @@ and doCondExp (asconst: bool)  (* Try to evaluate the conditional expression
   | _ ->
       let (se, e, t) = doExp asconst e (AExp None) in
       ignore (checkBool t e);
-      CEExp (se, if !lowerConstants then constFold asconst e else e)
+      CEExp (se, if !lowerConstants || asconst then constFold asconst e else e)
 
 and compileCondExp (asconst:bool) (ce: condExpRes) (st: chunk) (sf: chunk) : chunk =
   match ce with


### PR DESCRIPTION
### TODO
- [ ] Review other uses of `lowerConstants`.