### PR TITLE
Remove hardcoded constant folding for unary minus in `cabs2cil`

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -4009,12 +4009,7 @@ and doExp (asconst: bool)   (* This expression is used as a constant *)
         let (se, e', t) = doExp asconst e (AExp None) in
         if isIntegralType t then
           let tres = integralPromotion t in
-          let fallback = UnOp(Neg, makeCastT ~kind:IntegerPromotion ~e:e' ~oldt:t ~newt:tres, tres) in
-          let e'' =
-            match e', tres with
-            | Const(CInt(i, _, _)), TInt(ik, _) -> const_if_not_overflow fallback ik (neg_cilint i)
-            | _ -> fallback
-          in
+          let e'' = UnOp(Neg, makeCastT ~kind:IntegerPromotion ~e:e' ~oldt:t ~newt:tres, tres) in
           finishExp se e'' tres
         else
           if isArithmeticType t then


### PR DESCRIPTION
We want integer overflow safety checks from our internal dashboard implementation to be reported for unary minus operations to constants. However, when constant folding is enabled, this case should still handled in `cil.ml`:

```ocaml
| UnOp(unop, e1, tres) -> begin
  ...
  match unop with
    Neg -> const_if_not_overflow (UnOp(Neg,Const(CInt(i,ik,s)),tres)) tk (neg_cilint ic)
    ...
```