### PR TITLE
Accept repeated prototypes for extern inline functions, without dropping the prototyped function

### DIFF
--- a/src/frontc/cabs2cil.ml
+++ b/src/frontc/cabs2cil.ml
@@ -1976,7 +1976,7 @@ let makeGlobalVarinfo (isadef: bool) (vi: varinfo) : varinfo * bool =
 
     (* New-style extern inline handling: the real definition replaces the extern
        inline one *)
-    if (not !Cil.oldstyleExternInline) && oldvi.vstorage = Extern && oldvi.vinline then begin
+    if (not !Cil.oldstyleExternInline) && oldvi.vstorage = Extern && oldvi.vinline && isadef then begin
       H.remove alreadyDefined oldvi.vname;
       theFile := Util.list_map (fun g -> match g with
 	   | GFun (fi, l) when fi.svar == oldvi -> GVarDecl(fi.svar, l)

--- a/test/small1/extinline4.c
+++ b/test/small1/extinline4.c
@@ -1,0 +1,13 @@
+/* Repeating a prototype should be harmless. */
+
+extern void f(void);
+extern inline __attribute__((always_inline)) void g()
+{
+	f();
+}
+
+extern inline __attribute__((always_inline)) void g();
+void v(void)
+{
+	g();
+}

--- a/test/testcil.pl
+++ b/test/testcil.pl
@@ -693,6 +693,7 @@ addTest("runall/alpha");
 addTest("testrun/blockattr2 USECFG=1");
 addTest("testrun/extinline2");
 addTest("test/extinline3");
+addTest("test/extinline4");
 addTest("testrun/bool");
 addTest("testrun/var_named_hidden");
 addTest("testrun/macro_hidden");


### PR DESCRIPTION
Given code like this:
```
extern void f(void);
extern inline __attribute__((always_inline)) void g()
{
        f();
}

extern inline __attribute__((always_inline)) void g();
void v(void)
{
        g();
}
```
... CIL will replace its definition of `g()` when it sees the second prototype, making it appear wrongly to be a prototype-only function. The C that is printed will lack the definition of `g()`. Then compilation will fail with an error like the following.
```
./extinline4.cil.c: In function ‘v’:
./extinline4.cil.c:5:59: error: inlining failed in call to ‘always_inline’ ‘g’: function body not available
    5 | __inline extern void ( __attribute__((__always_inline__)) g)(void) ;
      |                                                           ^
./extinline4.cil.c:13:3: note: called from here
   13 |   g();
      |   ^~~
```
This PR fixes this, by splitting out the cases of newly seen function definitions versus declarations. 