### PR TITLE
Fix machdep generation on native Windows

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -63,10 +63,23 @@
  (action (with-stdout-to %{target} (run ./modelConfigure.exe --real-gcc %{read-lines:../bin/real-gcc} -m 64))))
 
 (rule
+ (enabled_if (<> %{os_type} Win32))
  (deps machdep32 machdep64)
  (target machdep.ml)
  (action (run %{bin:cppo} -V OCAML:%{ocaml_version}
               %{dep:machdep.cppo.ml} -x machdep:./%{dep:machdep-ml.exe}
+              -o %{target})))
+
+; cppo runs the -x command through cmd.exe on Windows, which does not
+; understand the "./" prefix that %{dep:...} produces — spell it ".\"
+; instead (a bare name would break when cmd's current-directory lookup
+; is disabled via NoDefaultCurrentDirectoryInExePath).
+(rule
+ (enabled_if (= %{os_type} Win32))
+ (deps machdep32 machdep64 machdep-ml.exe)
+ (target machdep.ml)
+ (action (run %{bin:cppo} -V OCAML:%{ocaml_version}
+              %{dep:machdep.cppo.ml} -x "machdep:.\\machdep-ml.exe"
               -o %{target})))
 
 (ocamllex formatlex)

--- a/src/dune
+++ b/src/dune
@@ -62,18 +62,15 @@
  (target gcc64model)
  (action (with-stdout-to %{target} (run ./modelConfigure.exe --real-gcc %{read-lines:../bin/real-gcc} -m 64))))
 
+; separate rules for Windows and non-Windows due to different command line prefix
 (rule
  (enabled_if (<> %{os_type} Win32))
- (deps machdep32 machdep64)
+ (deps machdep32 machdep64 machdep-ml.exe)
  (target machdep.ml)
  (action (run %{bin:cppo} -V OCAML:%{ocaml_version}
-              %{dep:machdep.cppo.ml} -x machdep:./%{dep:machdep-ml.exe}
+              %{dep:machdep.cppo.ml} -x machdep:./machdep-ml.exe
               -o %{target})))
 
-; cppo runs the -x command through cmd.exe on Windows, which does not
-; understand the "./" prefix that %{dep:...} produces — spell it ".\"
-; instead (a bare name would break when cmd's current-directory lookup
-; is disabled via NoDefaultCurrentDirectoryInExePath).
 (rule
  (enabled_if (= %{os_type} Win32))
  (deps machdep32 machdep64 machdep-ml.exe)

--- a/src/machdepArchConfigure.ml
+++ b/src/machdepArchConfigure.ml
@@ -9,11 +9,12 @@ let () =
     ]
   in
   C.main ~name:"model" ~args (fun c ->
-      (* On Windows this is executed through cmd.exe, which does not
-         understand the "./" prefix ("'.' is not recognized ..."). *)
-      let exe = (if Sys.win32 then ".\\" else "./") ^ "machdep" ^ !m ^ "-ml.exe" in
+      let exe = "machdep" ^ !m ^ "-ml.exe" in
       let {C.Process.exit_code; stdout; stderr} = C.Process.run c !real_gcc ["-D_GNUCC"; "-include"; "machdep" ^ !m ^ "-config.h"; "-m" ^ !m; "machdep-ml.c"; "-o"; exe] in
       if exit_code = 0 then (
+        (* On Windows this is executed through cmd.exe, which does not
+           understand the "./" prefix ("'.' is not recognized ..."). *)
+        let exe = (if Sys.win32 then ".\\" else "./") ^ exe in
         let {C.Process.stdout; stderr; exit_code} = C.Process.run c exe [] in
         assert (exit_code = 0);
         Printf.printf "Some {%s}" stdout

--- a/src/machdepArchConfigure.ml
+++ b/src/machdepArchConfigure.ml
@@ -9,7 +9,9 @@ let () =
     ]
   in
   C.main ~name:"model" ~args (fun c ->
-      let exe = "./machdep" ^ !m ^ "-ml.exe" in
+      (* On Windows this is executed through cmd.exe, which does not
+         understand the "./" prefix ("'.' is not recognized ..."). *)
+      let exe = (if Sys.win32 then ".\\" else "./") ^ "machdep" ^ !m ^ "-ml.exe" in
       let {C.Process.exit_code; stdout; stderr} = C.Process.run c !real_gcc ["-D_GNUCC"; "-include"; "machdep" ^ !m ^ "-config.h"; "-m" ^ !m; "machdep-ml.c"; "-o"; exe] in
       if exit_code = 0 then (
         let {C.Process.stdout; stderr; exit_code} = C.Process.run c exe [] in

--- a/src/modelConfigure.ml
+++ b/src/modelConfigure.ml
@@ -9,7 +9,9 @@ let () =
     ]
   in
   C.main ~name:"model" ~args (fun c ->
-      let exe = "./machdep-ml" ^ !m ^ ".exe" in
+      (* On Windows this is executed through cmd.exe, which does not
+         understand the "./" prefix ("'.' is not recognized ..."). *)
+      let exe = (if Sys.win32 then ".\\" else "./") ^ "machdep-ml" ^ !m ^ ".exe" in
       let {C.Process.exit_code; stdout; stderr} = C.Process.run c !real_gcc ["-D_GNUCC"; "-include"; "machdep" ^ !m ^ "-config.h"; "-m" ^ !m; "machdep-ml.c"; "-o"; exe] in
       if exit_code = 0 then (
         let {C.Process.stdout; stderr; exit_code} = C.Process.run c exe ["--env"] in

--- a/src/modelConfigure.ml
+++ b/src/modelConfigure.ml
@@ -9,11 +9,12 @@ let () =
     ]
   in
   C.main ~name:"model" ~args (fun c ->
-      (* On Windows this is executed through cmd.exe, which does not
-         understand the "./" prefix ("'.' is not recognized ..."). *)
-      let exe = (if Sys.win32 then ".\\" else "./") ^ "machdep-ml" ^ !m ^ ".exe" in
+      let exe = "machdep-ml" ^ !m ^ ".exe" in
       let {C.Process.exit_code; stdout; stderr} = C.Process.run c !real_gcc ["-D_GNUCC"; "-include"; "machdep" ^ !m ^ "-config.h"; "-m" ^ !m; "machdep-ml.c"; "-o"; exe] in
       if exit_code = 0 then (
+        (* On Windows this is executed through cmd.exe, which does not
+           understand the "./" prefix ("'.' is not recognized ..."). *)
+        let exe = (if Sys.win32 then ".\\" else "./") ^ exe in
         let {C.Process.stdout; stderr; exit_code} = C.Process.run c exe ["--env"] in
         assert (exit_code = 0);
         print_string stdout;


### PR DESCRIPTION
The machdep configure steps execute the freshly compiled machdep-ml.exe through a shell. On Windows that shell is cmd.exe, which does not understand the "./" prefix, so building goblint-cil fails with:

    '.' is not recognized as an internal or external command
    Error: Command "././machdep-ml.exe" exited with status 1

Three call sites are affected:

- machdepArchConfigure.ml / modelConfigure.ml: run the helper as ".\machdep...-ml.exe" when Sys.win32
- src/dune: the cppo -x command is also run through cmd.exe, and %{dep:machdep-ml.exe} expands with a "./" prefix. Split the rule with enabled_if on %{os_type} and spell the command ".\" on Win32 (a bare name would break when cmd's current-directory lookup is disabled via NoDefaultCurrentDirectoryInExePath).

Verified on Windows 11 with opam 2.5 (MSYS2 Unix tools) and the mingw-w64 x86_64 OCaml 4.14.4 toolchain: dune build -p goblint-cil succeeds. Unix behaviour is unchanged.